### PR TITLE
s/cacade/cascade

### DIFF
--- a/tests/spec.js
+++ b/tests/spec.js
@@ -3,7 +3,7 @@
  * @type {Object}
  */
 var spec = {
-	'whitespace cacade true': {
+	'whitespace cascade true': {
 		sample: `
 			html {
 				width: 0;  	     


### PR DESCRIPTION
Just saw this typo for `cacade`, should be `cascade` 😄 