### PR TITLE
Allow the colon to be the last character on the line without inserting the semicolon

### DIFF
--- a/stylis.js
+++ b/stylis.js
@@ -377,6 +377,7 @@
 						// valid characters that
 						// may precede a newline
 						switch (tail) {
+							case COLON:
 							case COMMA:
 							case NULL:
 							case TAB:

--- a/tests/spec.js
+++ b/tests/spec.js
@@ -981,6 +981,17 @@ var spec = {
 		`width: 0`+
 		`h3{display: none;}`
 	},
+	'multiline declaration': {
+		sample: `
+			html {
+			  background-image:
+			    linear-gradient(0deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.8)),
+			    url(/static/background.svg);
+			}
+		`,
+		expected: ``+
+		`.user html{background-image:    linear-gradient(0deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.8)),    url(/static/background.svg);}`
+	},
 	'middleware contexts': {
 		options: {
 			plugins: function (context, content, selector, parents, line, column, length) {


### PR DESCRIPTION
I found out that my styles have broken after last Stylis upgrades (I'm using styled-jsx):

```css
html {
  background-image:
    linear-gradient(0deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.8)),
    url(/static/background.svg);
}
```

A semicolon was inserted after `background-image:`, which resulted in the rule being broken and having no background on my website 😢 I double checked and the original rule is valid CSS.