### PR TITLE
Add failing test for shorthand properties over multiple lines

### DIFF
--- a/tests/spec.js
+++ b/tests/spec.js
@@ -1308,6 +1308,16 @@ var spec = {
 		expected: ``+
 		`.user html{background-image: linear-gradient(0deg,rgba(255,255,255,0.8),rgba(255,255,255,0.8)), url(/static/background.svg);}`
 	},
+	'multiline declaration with subproperties': {
+		sample: `
+			html {
+			  background-image: linear-gradient(0deg, red, blue) center
+					center no-repeat;
+			}
+		`,
+		expected: ``+
+		`.user html{background-image: linear-gradient(0deg,red,blue) center center no-repeat;}`
+	},
 	'nesting selector multiple levels': {
 		sample: `
 			a {


### PR DESCRIPTION
Currently when writing something like:

```
background-image: linear-gradient(0deg, red, blue) center
  center no-repeat;
```

It gets interpreted as though `center` is its own property:

```
background-image:linear-gradient(0deg,red,blue) center;center:no-repeat;
```

The CSS spec does seem to allow breaking shorthands over multiple lines.

Not sure on best way to fix, so this PR is simply a failing test as an example. I imagine this would also happen for other shorthand properties like animations/transitions!