### PR TITLE
docs: remove options key from set example

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ When using the factory pattern the if an object is passed as optional `options` 
 
 ```javascript
 // all options except compress and cascade are enabled by default
-stylis.set(options: {
+stylis.set({
 	// (dis/en)able :global selectors
 	global: {Boolean}
 


### PR DESCRIPTION
Greetings,

Docs example misled me to call `set({options:{cascade:false}})`. Perhaps it would be better to remove "options" from that example?