### PR TITLE
Reduce scope for text- properties prefixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 3.4.9 (Unreleased)
+## 3.4.10 (Unreleased)
+
+- patch for incorrect vendor prefixing of many `text-` properties
+
+## 3.4.9 February 15, 2018
 
 - patch `text-decoration` to re-include vendor `-webkit-` prefix.
 - patch vendor prefix of height/width keyword varients i.e `stretch/fit-content`.
@@ -630,4 +634,3 @@ stylis.set({
 ## 0.6.2 (December 04, 2016)
 
 - patch flat css `stylis('#id', 'color:red;')` to act as a block `stylis('#id', '&{color:red;}')`
-

--- a/stylis.js
+++ b/stylis.js
@@ -1008,7 +1008,8 @@
 		switch (hash) {
 			// text-decoration/text-size-adjust: t, e, x
 			case 1015: {
-				return webkit + out + out
+				// text-size-adjust, - / text-decoration, d
+				return (out.charCodeAt(9) === DASH || out.charCodeAt(5) === 100) ? webkit + out + out : out
 			}
 			// filter/fill f, i, l
 			case 951: {


### PR DESCRIPTION
fixes #95 

Limits the `-webkit-` prefix to only be applied to `text-size-adjust` using the previous heuristics, and adds a specific case for `text-decoration` instead.