### PR TITLE
Remove duplicated case for quotes

### DIFF
--- a/stylis.js
+++ b/stylis.js
@@ -677,12 +677,7 @@
 							break
 						}
 						// quotes
-						case DOUBLEQUOTE: {
-							if (comment === 0) {
-								quote = quote === code ? 0 : (quote === 0 ? code : quote)
-							}
-							break
-						}
+						case DOUBLEQUOTE:
 						case SINGLEQUOTE: {
 							if (comment === 0) {
 								quote = quote === code ? 0 : (quote === 0 ? code : quote)


### PR DESCRIPTION
I just noticed that this was the same for single and double quotes so the first one could be removed and fallthrough :)