### PR TITLE
Remove unneccesary switch in proxy 

### DIFF
--- a/stylis.js
+++ b/stylis.js
@@ -1487,18 +1487,8 @@
 				}
 			}
 		}
-
-		switch (out) {
-			case void 0:
-			case false:
-			case true:
-			case null:
-			case content: {
-				break
-			}
-			default: {
-				return out
-			}
+		if (out !== content) {
+		  return out
 		}
 	}
 


### PR DESCRIPTION
The switch statement here was unnecessary since `out` is only set to something other than `content` if it's not those falsy values in the previous switch