### PR TITLE
Don't remove whitespace before ::placeholder

### DIFF
--- a/stylis.js
+++ b/stylis.js
@@ -821,6 +821,10 @@
 								}
 								case TAB:
 								case SPACE: {
+									// check for "::placeholder" after space and don't remove the space
+									if (body.charCodeAt(caret+1) === COLON && body.charCodeAt(caret+2) === COLON && body.charCodeAt(caret+3) === PLACEHOLDER) {
+										break
+									}
 									switch (tail) {
 										case NULL:
 										case OPENBRACES:

--- a/stylis.js
+++ b/stylis.js
@@ -822,7 +822,7 @@
 								case TAB:
 								case SPACE: {
 									// check for "::placeholder" after space and don't remove the space
-									if (body.charCodeAt(caret+1) === COLON && body.charCodeAt(caret+2) === COLON && body.charCodeAt(caret+3) === PLACEHOLDER) {
+									if (body.charCodeAt(caret+1) === COLON && body.substr(caret+3, 15).match(/^(-webkit-input-|-moz-|ms-input-)?p.*/)) {
 										break
 									}
 									switch (tail) {

--- a/tests/spec.js
+++ b/tests/spec.js
@@ -1978,6 +1978,24 @@ var spec = {
 				opacity: 0; }
 		`,
 		expected: '.Test--Input ::-webkit-input-placeholder{opacity:0;}.Test--Input ::-moz-placeholder{opacity:0;}.Test--Input :-ms-input-placeholder{opacity:0;}.Test--Input ::placeholder{opacity:0;}'
+	},
+	'retain pre-prefixed placeholder whitespace with cascade false': {
+		options: {
+			cascade: false,
+			prefix: false,
+		},
+		selector: '',
+		sample: `
+			.Test--Input ::-webkit-input-placeholder {
+				opacity: 0; }
+			.Test--Input ::-moz-placeholder {
+				opacity: 0; }
+			.Test--Input :-ms-input-placeholder {
+				opacity: 0; }
+			.Test--Input ::placeholder {
+				opacity: 0; }
+		`,
+		expected: '.Test--Input ::-webkit-input-placeholder{opacity:0;}.Test--Input ::-moz-placeholder{opacity:0;}.Test--Input :-ms-input-placeholder{opacity:0;}.Test--Input ::placeholder{opacity:0;}'
 	}
 };
 

--- a/tests/spec.js
+++ b/tests/spec.js
@@ -1966,6 +1966,18 @@ var spec = {
 	'comments(context character VIII)': {
 		sample: `background: url[img}.png];.a {background: url[img}.png];}`,
 		expected: `.user{background:url[img}.png];}.user .a{background:url[img}.png];}`
+	},
+	'retain placeholder whitespace with cascade false': {
+		options: {
+			cascade: false,
+			prefix: true,
+		},
+		selector: '',
+		sample: `
+			.Test--Input ::placeholder {
+				opacity: 0; }
+		`,
+		expected: '.Test--Input ::-webkit-input-placeholder{opacity:0;}.Test--Input ::-moz-placeholder{opacity:0;}.Test--Input :-ms-input-placeholder{opacity:0;}.Test--Input ::placeholder{opacity:0;}'
 	}
 };
 


### PR DESCRIPTION
Adds special handling for CSS like `div.input ::placeholder { ... }` when `cascade` is set to false.

We are using a UI library which defines the placeholder CSS like that and noticed that the whitespace before the "::placeholder"-selectors was being removed and the placeholders looked wrong. I tracked this down from next.js => styled-jsx => stylis and noticed it only happens when `cascade` is false, which styled-jsx always uses.

Took a good few hours to figure out the fix this, but I feel like my solution might not be ideal :) Let me know what you think!