### PR TITLE
WIP: Fix comment with /*! ... */

### DIFF
--- a/tests/spec.js
+++ b/tests/spec.js
@@ -1966,6 +1966,11 @@ var spec = {
 	'comments(context character VIII)': {
 		sample: `background: url[img}.png];.a {background: url[img}.png];}`,
 		expected: `.user{background:url[img}.png];}.user .a{background:url[img}.png];}`
+	},
+	'comments(bang at start)': {
+		selector: '',
+		sample: `/*! test */\nbody { color: red; }`,
+		expected: `body{color:red;}`
 	}
 };
 


### PR DESCRIPTION
Work In Progress, do not merge!

Couldn't work out a fix yet, but wanted to create the pull request already in case anyone has any ideas for solving this :) This PR includes a failing test case.

**Description:**

[normalize.css](https://github.com/necolas/normalize.css/blob/master/normalize.css#L1) contains this first-line comment:

```
/*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
```

and stylis currently converts this to:

```
{/*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */}
```
