### PR TITLE
Added regression test for broken parsing of urls as comments

### DIFF
--- a/tests/spec.js
+++ b/tests/spec.js
@@ -529,6 +529,17 @@ var spec = {
 		`background-image:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEYAAAABCAIAAADsEU8HAAAACXBIW`+
 		`XMAAAsTAAALEwEAmpwYAAAAIklEQVQI12P8//8/Aw4wbdq0rKysAZG1trbGJXv06FH8sgDIJBbBfp+hFAAAAABJRU5ErkJggg==");}`
 	},
+	'urls with nesting': {
+		sample:
+			`.level-1 { `+
+			`  background: url(http://url.com/in-level-1); `+
+			`  .level-2 { background: url(http://url.com/in-level-2); }`+
+			`}`+
+			`.also-level-1 { background: url(http://url.com/again-in-level-1); }`,
+		expected: `.user .level-1{background:url(http://url.com/in-level-1);}`+
+		`.user .level-1 .level-2{background:url(http://url.com/in-level-2);}`+
+		`.user .also-level-1{background:url(http://url.com/again-in-level-1);}`
+	},
 	'last semicolon omission': {
 		sample: `
 			.content {


### PR DESCRIPTION
The latest released version of stylist (v3.5.3 / 730eaf78a2e2b300fe5fa256ca5e9b0d5c51b17a) breaks nested selectors on 1 line if they contain urls due to single line comment parsing.

The experimental rewrite (master) seems to have fixed this problem. Here's a regression test to ensure it doesn't get reintroduced. When you run this test against v3.5.3, this is the output:

```
212 'failed: ' 'urls with nesting' '\n\n' '.user .level-1{background:url(http://url.com/in-level-1);}.user .level-1 .level-2{background:url(http://url.com/in-level-2);}.user .level-1 .level-2 .also-level-1{background:url(http://url.com/again-in-level-1);}'
194 'expected: ' '\n\n' '.user .level-1{background:url(http://url.com/in-level-1);}.user .level-1 .level-2{background:url(http://url.com/in-level-2);}.user .also-level-1{background:url(http://url.com/again-in-level-1);}' '\n\n---------------\n\n'
false
```

Please note the duplication of `.level-1 .level-2` before `.also-level-1`.

It would be nice to have a new release v3.5.4 based on the old codebase (pre rewrite) which includes this test and the fix.