### PR TITLE
Don't rely on the constructor property when checking plugin type

### DIFF
--- a/stylis.js
+++ b/stylis.js
@@ -1566,20 +1566,14 @@
 				break
 			}
 			default: {
-				switch (plugin.constructor) {
-					case Array: {
-						for (var i = 0, length = plugin.length; i < length; ++i) {
-							use(plugin[i])
-						}
-						break
+				if (Object.prototype.toString.call(plugin) === '[object Array]') {
+					for (var i = 0, length = plugin.length; i < length; ++i) {
+						use(plugin[i])
 					}
-					case Function: {
-						plugins[plugged++] = plugin
-						break
-					}
-					case Boolean: {
-						unkwn = !!plugin|0
-					}
+				} else if (typeof plugin === 'function') {
+					plugins[plugged++] = plugin
+				} else if (plugin === true || plugin === false || plugin instanceof Boolean) {
+					unkwn = !!plugin|0
 				}
 			}
  		}


### PR DESCRIPTION
This change fixes the issue described in https://github.com/thysultan/stylis.js/issues/125

I ran the tests in https://github.com/postcss/benchmark before and after my change and I did not notice any deterioration in performance.
```
$ npm test preprocessors
> @ test /home/daniel/Code/benchmark
> gulp "preprocessors"
[16:16:30] Using gulpfile ~/Code/benchmark/gulpfile.js
[16:16:30] Starting 'bootstrap'...
[16:16:31] Finished 'bootstrap' after 340 ms
[16:16:31] Starting 'preprocessors'...
[16:16:32] Running suite Bootstrap [/home/daniel/Code/benchmark/preprocessors.js]...
[16:16:38]    LibSass x 6.81 ops/sec ±4.33% (38 runs sampled)
[16:16:44]    LibSass sync x 8.07 ops/sec ±2.04% (25 runs sampled)
[16:16:52]    Dart Sass x 2.64 ops/sec ±20.86% (19 runs sampled)
[16:16:59]    Dart Sass sync x 4.92 ops/sec ±11.15% (18 runs sampled)
[16:17:05]    Rework x 14.90 ops/sec ±2.83% (72 runs sampled)
[16:17:10]    PostCSS x 18.44 ops/sec ±12.36% (51 runs sampled)
[16:17:17]    Stylecow x 3.51 ops/sec ±6.69% (22 runs sampled)
[16:17:24]    Stylus x 6.51 ops/sec ±22.29% (39 runs sampled)
[16:17:30]    Less x 5.25 ops/sec ±15.40% (30 runs sampled)
[16:17:36]    Stylis x 36.07 ops/sec ±15.57% (68 runs sampled)
[16:17:36] Fastest test is Stylis at 1.96x faster than PostCSS
Stylis:         28 ms  (2.0 times faster)
PostCSS:        54 ms
Rework:         67 ms  (1.2 times slower)
LibSass sync:   124 ms (2.3 times slower)
LibSass:        147 ms (2.7 times slower)
Stylus:         154 ms (2.8 times slower)
Less:           191 ms (3.5 times slower)
Dart Sass sync: 203 ms (3.7 times slower)
Stylecow:       285 ms (5.2 times slower)
Dart Sass:      379 ms (7.0 times slower)
[16:17:36] Finished 'preprocessors' after 1.08 min
$ npm test parsers
> @ test /home/daniel/Code/benchmark
> gulp "parsers"
[16:17:56] Using gulpfile ~/Code/benchmark/gulpfile.js
[16:17:56] Starting 'bootstrap'...
[16:17:56] Finished 'bootstrap' after 187 μs
[16:17:56] Starting 'parsers'...
[16:17:56] Running suite Bootstrap [/home/daniel/Code/benchmark/parsers.js]...
[16:18:02]    Rework x 19.30 ops/sec ±4.82% (37 runs sampled)
[16:18:08]    PostCSS x 36.85 ops/sec ±14.00% (51 runs sampled)
[16:18:14]    PostCSS Full x 10.74 ops/sec ±6.57% (49 runs sampled)
[16:18:19]    CSSOM x 55.05 ops/sec ±10.17% (62 runs sampled)
[16:18:25]    Mensch x 29.86 ops/sec ±7.64% (56 runs sampled)
[16:18:31]    Gonzales x 7.38 ops/sec ±4.72% (22 runs sampled)
[16:18:38]    Gonzales PE x 5.80 ops/sec ±13.15% (20 runs sampled)
[16:18:44]    CSSTree x 128 ops/sec ±1.51% (82 runs sampled)
[16:18:51]    ParserLib x 4.49 ops/sec ±5.03% (16 runs sampled)
[16:18:57]    Stylecow x 13.61 ops/sec ±8.92% (38 runs sampled)
[16:19:02]    Stylis x 51.79 ops/sec ±13.95% (62 runs sampled)
[16:19:02] Fastest test is CSSTree at 2.3x faster than CSSOM
CSSTree:      8 ms   (3.5 times faster)
CSSOM:        18 ms  (1.5 times faster)
Stylis:       19 ms  (1.4 times faster)
PostCSS:      27 ms
Mensch:       33 ms  (1.2 times slower)
Rework:       52 ms  (1.9 times slower)
Stylecow:     73 ms  (2.7 times slower)
PostCSS Full: 93 ms  (3.4 times slower)
Gonzales:     136 ms (5.0 times slower)
Gonzales PE:  173 ms (6.4 times slower)
ParserLib:    223 ms (8.2 times slower)
[16:19:02] Finished 'parsers' after 1.1 min
$ npm link stylis
/home/daniel/Code/benchmark/node_modules/stylis -> /usr/lib/node_modules/stylis -> /home/daniel/Code/stylis.js
$ npm test preprocessors
> @ test /home/daniel/Code/benchmark
> gulp "preprocessors"
[16:19:36] Using gulpfile ~/Code/benchmark/gulpfile.js
[16:19:36] Starting 'bootstrap'...
[16:19:36] Finished 'bootstrap' after 193 μs
[16:19:36] Starting 'preprocessors'...
[16:19:37] Running suite Bootstrap [/home/daniel/Code/benchmark/preprocessors.js]...
[16:19:43]    LibSass x 6.05 ops/sec ±4.82% (34 runs sampled)
[16:19:49]    LibSass sync x 7.91 ops/sec ±2.60% (24 runs sampled)
[16:19:57]    Dart Sass x 2.92 ops/sec ±20.98% (21 runs sampled)
[16:20:04]    Dart Sass sync x 5.30 ops/sec ±8.68% (18 runs sampled)
[16:20:09]    Rework x 16.03 ops/sec ±2.15% (77 runs sampled)
[16:20:15]    PostCSS x 17.36 ops/sec ±11.95% (47 runs sampled)
[16:20:22]    Stylecow x 3.36 ops/sec ±6.45% (21 runs sampled)
[16:20:28]    Stylus x 6.38 ops/sec ±17.44% (37 runs sampled)
[16:20:35]    Less x 5.35 ops/sec ±10.69% (29 runs sampled)
[16:20:41]    Stylis x 36.94 ops/sec ±14.17% (69 runs sampled)
[16:20:41] Fastest test is Stylis at 2.3x faster than Rework
Stylis:         27 ms  (2.1 times faster)
PostCSS:        58 ms
Rework:         62 ms  (1.1 times slower)
LibSass sync:   126 ms (2.2 times slower)
Stylus:         157 ms (2.7 times slower)
LibSass:        165 ms (2.9 times slower)
Less:           187 ms (3.2 times slower)
Dart Sass sync: 189 ms (3.3 times slower)
Stylecow:       298 ms (5.2 times slower)
Dart Sass:      342 ms (5.9 times slower)
[16:20:41] Finished 'preprocessors' after 1.07 min
$ npm test parsers
> @ test /home/daniel/Code/benchmark
> gulp "parsers"
[16:20:57] Using gulpfile ~/Code/benchmark/gulpfile.js
[16:20:57] Starting 'bootstrap'...
[16:20:57] Finished 'bootstrap' after 190 μs
[16:20:57] Starting 'parsers'...
[16:20:57] Running suite Bootstrap [/home/daniel/Code/benchmark/parsers.js]...
[16:21:03]    Rework x 20.80 ops/sec ±3.15% (39 runs sampled)
[16:21:09]    PostCSS x 40.94 ops/sec ±11.88% (56 runs sampled)
[16:21:15]    PostCSS Full x 10.73 ops/sec ±6.66% (49 runs sampled)
[16:21:21]    CSSOM x 56.27 ops/sec ±13.05% (65 runs sampled)
[16:21:26]    Mensch x 28.34 ops/sec ±10.49% (54 runs sampled)
[16:21:33]    Gonzales x 6.39 ops/sec ±7.82% (21 runs sampled)
[16:21:40]    Gonzales PE x 6.27 ops/sec ±11.61% (21 runs sampled)
[16:21:46]    CSSTree x 87.17 ops/sec ±7.96% (55 runs sampled)
[16:21:53]    ParserLib x 4.48 ops/sec ±5.95% (16 runs sampled)
[16:21:59]    Stylecow x 13.82 ops/sec ±7.56% (39 runs sampled)
[16:22:04]    Stylis x 50.94 ops/sec ±16.00% (61 runs sampled)
[16:22:04] Fastest test is CSSTree at 1.55x faster than CSSOM
CSSTree:      11 ms  (2.1 times faster)
CSSOM:        18 ms  (1.4 times faster)
Stylis:       20 ms  (1.2 times faster)
PostCSS:      24 ms
Mensch:       35 ms  (1.4 times slower)
Rework:       48 ms  (2.0 times slower)
Stylecow:     72 ms  (3.0 times slower)
PostCSS Full: 93 ms  (3.8 times slower)
Gonzales:     156 ms (6.4 times slower)
Gonzales PE:  160 ms (6.5 times slower)
ParserLib:    223 ms (9.1 times slower)
[16:22:04] Finished 'parsers' after 1.12 min
```