### PR TITLE
Fix cursor:image-set() prefixing

### DIFF
--- a/stylis.js
+++ b/stylis.js
@@ -56,7 +56,7 @@
 	var nullptn = /^\0+/g /* matches leading null characters */
 	var formatptn = /[\0\r\f]/g /* matches new line, null and formfeed characters */
 	var colonptn = /: */g /* splits animation rules */
-	var cursorptn = /zoo|gra/ /* assert cursor varient */
+	var cursorptn = /(zoo|gra)/ /* assert cursor varient */
 	var transformptn = /([,: ])(transform)/g /* vendor prefix transform, older webkit */
 	var animationptn = /,+\s*(?![^(]*[)])/g /* splits multiple shorthand notation animations */
 	var propertiesptn = / +\s*(?![^(]*[)])/g /* animation properties */
@@ -1129,7 +1129,16 @@
 			}
 			// cursor, c, u, r
 			case 1005: {
-				return cursorptn.test(out) ? out.replace(colonptn, ':' + webkit) + out.replace(colonptn, ':' + moz) + out : out
+				if (imgsrcptn.test(out)) {
+					return cursorptn.test(out)
+						? out.replace(cursorptn, webkit+'$1').replace(imgsrcptn, '$1'+webkit+'$2') +
+							out.replace(cursorptn, moz+'$1') + out
+						: out.replace(imgsrcptn, '$1'+webkit+'$2') + out
+				} else {
+					return cursorptn.test(out)
+						? out.replace(cursorptn, webkit+'$1') + out.replace(cursorptn, moz+'$1') + out
+						: out
+				}
 			}
 			// writing-mode, w, r, i
 			case 1000: {

--- a/tests/spec.js
+++ b/tests/spec.js
@@ -954,6 +954,8 @@ var spec = {
 		sample: `
 			background:image-set(url(foo.jpg) 2x);
 			background-image:image-set(url(foo.jpg) 2x);
+			cursor:image-set(url(foo.jpg) 2x),pointer;
+			cursor:image-set(url(foo.jpg) 2x),grab;
 		`,
 		expected: ``+
 		`.user{`+
@@ -961,6 +963,11 @@ var spec = {
 			`background:image-set(url(foo.jpg) 2x);`+
 			`background-image:-webkit-image-set(url(foo.jpg) 2x);`+
 			`background-image:image-set(url(foo.jpg) 2x);`+
+			`cursor:-webkit-image-set(url(foo.jpg) 2x),pointer;`+
+			`cursor:image-set(url(foo.jpg) 2x),pointer;`+
+			`cursor:-webkit-image-set(url(foo.jpg) 2x),-webkit-grab;`+
+			`cursor:image-set(url(foo.jpg) 2x),-moz-grab;`+
+			`cursor:image-set(url(foo.jpg) 2x),grab;`+
 		`}`
 	},
 	'animations': {


### PR DESCRIPTION
Fixes the issue in #130.

The behavior before was testing for a `cursor` value of  `grab`/`zoom` and then prefixing whatever came after the colon. This resulted in `cursor: image-set(foo.jpg, 2x), grab` becoming
```css
cursor: -webkit-image-set(foo.jpg, 2x), grab;
cursor: -moz-image-set(foo.jpg, 2x), grab;
cursor: image-set(foo.jpg, 2x), grab;
```

which is incorrect.

This patch changes the test to add an additional check for image-set, and if found prefixes both image-set and zoom/grab properly, otherwise just checks for zoom/grab.