### PR TITLE
Fix bug with @-ms-viewport

### DIFF
--- a/tests/spec.js
+++ b/tests/spec.js
@@ -62,9 +62,25 @@ var spec = {
 		`.user body{color:red;}`+
 		'}'+
 		`@viewport{min-width:640px;max-width:800px;}`+
+		`@-ms-viewport{width: device-width;}`+
 		`@counter-style list{system:fixed;symbols:url();suffix:" ";}`+
 		`@-moz-document url-prefix(){.user .selector{color:lime;}}`+
 		`@page{color:red;@bottom-right{content:counter(pages);margin-right:1cm;}width:none;}`
+	},
+	'at-rules-empty-selector': {
+		sample: `
+		@viewport {
+			min-width:640px;
+			max-width:800px;
+		}
+
+		@-ms-viewport {
+			width: device-width;
+		}`,
+		expected: ``+
+		`@viewport{min-width:640px;max-width:800px;}`+
+		`@-ms-viewport{width: device-width;}`,
+		selector: ``,
 	},
 	'monkey-patch some invalid css patterns': {
 		sample: `


### PR DESCRIPTION
Currently `@-ms-viewport` gets the selector nested inside of it, i.e.

```
@-ms-viewport { width: device-width; }
```
compiles to 

```
@-ms-viewport { .selector { width: device-width; } }
```

Moreover, if the selector is empty then it compiles to invalid CSS:

```
@-ms-viewport { { width: device-width; } }
```

This PR adds failing test cases for this. However, I could not see how to fix it. Hopefully somebody who knows the codebase a bit better can contribute this part.