### PR TITLE
Apply prefix for margin-inline-*, padding-inline-*

### DIFF
--- a/stylis.js
+++ b/stylis.js
@@ -1250,6 +1250,15 @@
 
 				break
 			}
+			// padding-inline-start, padding-inline-end / margin-inline-start, margin-inline-end
+			case 915:   
+			case 965: { 
+				if (out.indexOf('-inline-') > 5) {
+					cache = out.replace('-inline', '')
+					return webkit + cache + out;
+				}
+				break
+			}
 		}
 
 		return out

--- a/tests/spec.js
+++ b/tests/spec.js
@@ -597,6 +597,16 @@ var spec = {
 			& {
 				transition:transform 1s,transform all 400ms,text-transform;
 			}
+
+			div {
+				margin-inline-start:1px;
+				margin-inline-end:1px;
+			}
+
+			div {
+				padding-inline-start:1px;
+				padding-inline-end:1px;
+			}
 		`,
 		expected:
 			`.user html{-webkit-text-size-adjust:none;text-size-adjust:none;}`+
@@ -695,6 +705,20 @@ var spec = {
 			`-webkit-transition:-webkit-transform 1s,-webkit-transform all 400ms,text-transform;`+
 			`-webkit-transition:transform 1s,transform all 400ms,text-transform;`+
 			`transition:transform 1s,transform all 400ms,text-transform;`+
+			`}`+
+
+			`.user div{`+
+			`-webkit-margin-start:1px;`+
+			`margin-inline-start:1px;`+
+			`-webkit-margin-end:1px;`+
+			`margin-inline-end:1px;`+
+			`}`+
+
+			`.user div{`+
+			`-webkit-padding-start:1px;`+
+			`padding-inline-start:1px;`+
+			`-webkit-padding-end:1px;`+
+			`padding-inline-end:1px;`+
 			`}`
 	},
 	'vendor prefixing II': {


### PR DESCRIPTION
Added vendor prefix (-webkit-) for margin-inline-start, margin-inline-end, padding-inline-start, padding-inline-end.

I found `margin-inline-*` and `padding-inline-*` are not vendor auto-prefixed by `styled-components` whereas `postcss` does it. And also found that they account on `stylis` for vendor prefixing.

https://caniuse.com/#feat=mdn-css_properties_margin-inline-start
https://caniuse.com/#feat=mdn-css_properties_margin-inline-end

https://caniuse.com/#feat=mdn-css_properties_padding-inline-start
https://caniuse.com/#feat=mdn-css_properties_padding-inline-end