### PR TITLE
Remove unused assign util

### DIFF
--- a/src/Utility.js
+++ b/src/Utility.js
@@ -11,12 +11,6 @@ export var abs = Math.abs
 export var from = String.fromCharCode
 
 /**
- * @param {...object}
- * @return {object}
- */
-export var assign = Object.assign
-
-/**
  * @param {string} value
  * @param {number} length
  * @return {number}


### PR DESCRIPTION
Minifiers are usually afraid of unexpected side effects of getters so this would have been retained even if it stays unused.