### PR TITLE
Add a failing test case for rulesheet plugin in combination with prefixed keyframes

### DIFF
--- a/test/Middleware.js
+++ b/test/Middleware.js
@@ -4,8 +4,13 @@ const stack = []
 
 describe('Middleware', () => {
 	test('rulesheet', () => {
-  	serialize(compile(`.user{h1 {width:0;} @media{width:1;}}`), middleware([stringify, rulesheet(value => stack.push(value))]))
-  	expect(stack).to.deep.equal([`.user h1{width:0;}`, `@media{.user{width:1;}}`])
+  	serialize(compile(`.user{h1 {width:0;} @media{width:1;}} @keyframes foo{from{width:0;}to{width:1;}}}`), middleware([prefixer, stringify, rulesheet(value => stack.push(value))]))
+  	expect(stack).to.deep.equal([
+      `.user h1{width:0;}`,
+      `@media{.user{width:1;}}`,
+      '@-webkit-keyframes foo{from{width:0;}to{width:1;}}',
+      '@keyframes foo{from{width:0;}to{width:1;}}}'
+    ])
   })
 
   test('prefixer', () => {


### PR DESCRIPTION
Problem is that the return property contains both prefixed and original keyframes in a single string after being processed by `stringify`:
```js
{
    value: '@keyframes foo',
    root: null,
    type: '@keyframes',
    props: [ 'foo' ],
    children: [ [Object], [Object] ],
    line: 1,
    column: 54,
    length: 0,
    prefix: '@-webkit-keyframes foo{from{width:0;}to{width:1;}}',
    return: '@-webkit-keyframes foo{from{width:0;}to{width:1;}}@keyframes foo{from{width:0;}to{width:1;}}'
}
```
and this gets passed to the `rulesheet` plugin as a single rule which is incorrect.