### PR TITLE
Fixed double declarations caused by the prefixer

### DIFF
--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -7,6 +7,8 @@ import {hash, match, charat, strlen, indexof, replace} from './Utility.js'
  * @return {string}
  */
 export function prefix (value, length) {
+	var input = value
+
 	if (length > 0)
 		switch (hash(value, length)) {
 			// @keyframes
@@ -53,7 +55,9 @@ export function prefix (value, length) {
 				value = replace(value, /(.*)(zoom-\w+|grab\w*)(.*)/, '$1' + WEBKIT + '$2$3$1' + MOZ + '$2$3')
 			// background, background-image
 			case 5495: case 3959:
-				return replace(value, /([^-])(image-set\()/, '$1' + WEBKIT + '$2')
+				value = replace(value, /([^-])(image-set\()/, '$1' + WEBKIT + '$2')
+				if (strlen(input) === strlen(value)) break
+				return value
 			// justify-content
 			case 4968:
 				return replace(replace(value, /(.+:)(flex-)?(.*)/, WEBKIT + 'box-pack:$3' + MS + 'flex-pack:$3'), /s.+-b[^;]+/, 'justify') + WEBKIT + value

--- a/test/Prefixer.js
+++ b/test/Prefixer.js
@@ -31,6 +31,7 @@ describe('Prefixer', () => {
 
 	test('cursor', () => {
 		expect(prefix(`cursor:grab;`, 6)).to.equal([`cursor:-webkit-grab;`, `cursor:-moz-grab;`].join(''))
+		expect(prefix(`cursor:pointer;`, 6)).to.equal('')
 		expect(prefix(`cursor:image-set(url(foo.jpg) 2x), grab;`, 6)).to.equal([
 			`cursor:-webkit-image-set(url(foo.jpg) 2x), -webkit-grab;`,
 			`cursor:image-set(url(foo.jpg) 2x), -moz-grab;`
@@ -135,7 +136,9 @@ describe('Prefixer', () => {
 
 	test('background', () => {
 		expect(prefix(`background:image-set(url(foo.jpg) 2x);`, 10)).to.equal([`background:-webkit-image-set(url(foo.jpg) 2x);`].join(''))
+		expect(prefix(`background:hotpink;`, 10)).to.equal('')
 		expect(prefix(`background-image:image-set(url(foo.jpg) 2x);`, 16)).to.equal([`background-image:-webkit-image-set(url(foo.jpg) 2x);`].join(''))
+		expect(prefix(`background-image:url(foo.jpg);`, 16)).to.equal('')
 	})
 
 	test('background-clip', () => {


### PR DESCRIPTION
Currently:
```js
const stylis = styles => serialize(compile(styles), middleware([prefixer, stringify]))

stylis(`body{background:white;}`) === 'body{background:white;background:white;}'
```
After the fix
```js
stylis(`body{background:white;}`) === 'body{background:white;}'
```

I've looked through all the other prefixing rules and it seems to me that those were the only affected ones (other are already guarded somehow or should always produce a prefixed value), but you can double-check this.