### PR TITLE
Move @import rule in a sample test input

### DIFF
--- a/test/Middleware.js
+++ b/test/Middleware.js
@@ -4,13 +4,13 @@ const stack = []
 
 describe('Middleware', () => {
 	test('rulesheet', () => {
-  	serialize(compile(`.user{ h1 {width:0;} @media{width:1;}@keyframes name{from{width:0;}to{width:1;}}}@import url('something.com/file.css');`), middleware([prefixer, stringify, rulesheet(value => stack.push(value))]))
+  	serialize(compile(`@import url('something.com/file.css');.user{ h1 {width:0;} @media{width:1;}@keyframes name{from{width:0;}to{width:1;}}}`), middleware([prefixer, stringify, rulesheet(value => stack.push(value))]))
   	expect(stack).to.deep.equal([
+      `@import url('something.com/file.css');`,
       `.user h1{width:0;}`,
       `@media{.user{width:1;}}`,
       `@-webkit-keyframes name{from{width:0;}to{width:1;}}`,
       `@keyframes name{from{width:0;}to{width:1;}}`,
-      `@import url('something.com/file.css');`
     ])
   })
 


### PR DESCRIPTION
v3 was special-casing `@import` (moving it to the front) so this has been producing a valid css output. Without the special-casing, this is invalid CSS as `@import` must come before other rules (might come after `@charset` though). I believe it's better for tests to reflect the correct usage hence this change.