### PR TITLE
Fix issues around prefixing pseudos

### DIFF
--- a/src/Middleware.js
+++ b/src/Middleware.js
@@ -52,12 +52,12 @@ export function prefixer (element, index, children, callback) {
 						switch (match(value, /(::plac\w+|:read-\w+)/)) {
 							// :read-(only|write)
 							case ':read-only': case ':read-write':
-								return serialize([copy(replace(value, /(read-\w+)/, MOZ + '$1'), element, '')], callback)
+								return serialize([copy(replace(value, /:(read-\w+)/, ':' + MOZ + '$1'), element, '')], callback)
 							// :placeholder
 							case '::placeholder':
 								return serialize([
-									copy(replace(value, /(plac\w+)/, WEBKIT + 'input-$1'), element, ''),
-									copy(replace(value, /(plac\w+)/, MOZ + '$1'), element, ''),
+									copy(replace(value, /:(plac\w+)/, ':' + WEBKIT + 'input-$1'), element, ''),
+									copy(replace(value, /:(plac\w+)/, ':' + MOZ + '$1'), element, ''),
 									copy(replace(value, /:(plac\w+)/, MS + 'input-$1'), element, '')
 								], callback)
 						}

--- a/src/Middleware.js
+++ b/src/Middleware.js
@@ -49,16 +49,16 @@ export function prefixer (element, index, children, callback) {
 			case RULESET:
 				if (element.length)
 					return combine(element.props, function (value) {
-						switch (match(value, /(::place.+|:read-.+)/)) {
+						switch (match(value, /(::plac\w+|:read-\w+)/)) {
 							// :read-(only|write)
 							case ':read-only': case ':read-write':
-								return serialize([copy(replace(value, /(read.+)/, MOZ + '$1'), element, '')], callback)
+								return serialize([copy(replace(value, /(read-\w+)/, MOZ + '$1'), element, '')], callback)
 							// :placeholder
 							case '::placeholder':
 								return serialize([
-									copy(replace(value, /(plac.+)/, WEBKIT + 'input-$1'), element, ''),
-									copy(replace(value, /(plac.+)/, MOZ + '$1'), element, ''),
-									copy(replace(value, /:(plac.+)/, MS + 'input-$1'), element, '')
+									copy(replace(value, /(plac\w+)/, WEBKIT + 'input-$1'), element, ''),
+									copy(replace(value, /(plac\w+)/, MOZ + '$1'), element, ''),
+									copy(replace(value, /:(plac\w+)/, MS + 'input-$1'), element, '')
 								], callback)
 						}
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -16,12 +16,12 @@ export function compile (value) {
  * @param {string[]} rule
  * @param {string[]} rules
  * @param {string[]} rulesets
- * @param {number} pseudo
+ * @param {number} inpseudo
  * @param {number[]} points
  * @param {string[]} declarations
  * @return {object}
  */
-export function parse (value, root, rule, rules, rulesets, pseudo, points, declarations) {
+export function parse (value, root, rule, rules, rulesets, inpseudo, points, declarations) {
 	var index = 0
 	var offset = 0
 	var length = 0
@@ -32,6 +32,7 @@ export function parse (value, root, rule, rules, rulesets, pseudo, points, decla
 	var scanning = 1
 	var ampersand = 1
 	var character = 0
+	var pseudo = 0
 	var type = ''
 	var props = rules
 	var children = rulesets
@@ -75,27 +76,27 @@ export function parse (value, root, rule, rules, rulesets, pseudo, points, decla
 					case 59: characters += ';'
 					// { rule/at-rule
 					default:
-						append(reference = ruleset(characters, root, index, offset, rules, points, type, props = [], children = [], length || pseudo), rulesets)
+						append(reference = ruleset(characters, root, index, offset, rules, points, type, props = [], children = [], (pseudo = pseudo || inpseudo)), rulesets)
 
 						if (character === 123)
 							if (offset === 0)
-								parse(characters, root, reference, props, rulesets, length, points, children)
+								parse(characters, root, reference, props, rulesets, pseudo, points, children)
 							else
 								switch (atrule) {
 									// d m s
 									case 100: case 109: case 115:
-										parse(value, reference, rule && append(ruleset(value, reference, 0, 0, rules, points, type, rules, props = [], length || pseudo), children), rules, children, length, points, rule ? props : children)
+										parse(value, reference, rule && append(ruleset(value, reference, 0, 0, rules, points, type, rules, props = [], pseudo), children), rules, children, pseudo, points, rule ? props : children)
 										break
 									default:
-										parse(characters, reference, reference, [''], children, length, points, children)
+										parse(characters, reference, reference, [''], children, pseudo, points, children)
 								}
 				}
 
-				index = length = offset = 0, variable = ampersand = 1, type = characters = ''
+				index = length = pseudo = offset = 0, variable = ampersand = 1, type = characters = ''
 				break
 			// :
 			case 58:
-				length = strlen(characters), property = previous
+				length = strlen(characters), property = previous, pseudo = 1
 			default:
 				switch (characters += from(character), character * variable) {
 					// &

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -16,15 +16,15 @@ export function compile (value) {
  * @param {string[]} rule
  * @param {string[]} rules
  * @param {string[]} rulesets
- * @param {number} inpseudo
+ * @param {number[]} pseudo
  * @param {number[]} points
  * @param {string[]} declarations
  * @return {object}
  */
-export function parse (value, root, rule, rules, rulesets, inpseudo, points, declarations) {
+export function parse (value, root, rule, rules, rulesets, pseudo, points, declarations) {
 	var index = 0
 	var offset = 0
-	var length = 0
+	var length = pseudo
 	var atrule = 0
 	var property = 0
 	var previous = 0
@@ -32,7 +32,6 @@ export function parse (value, root, rule, rules, rulesets, inpseudo, points, dec
 	var scanning = 1
 	var ampersand = 1
 	var character = 0
-	var pseudo = 0
 	var type = ''
 	var props = rules
 	var children = rulesets
@@ -69,34 +68,34 @@ export function parse (value, root, rule, rules, rulesets, inpseudo, points, dec
 					case 0: case 125: scanning = 0
 					// ;
 					case 59 + offset:
-						if (length > 0)
-							append(property > 32 ? declaration(characters + ';', rule, length) : declaration(replace(characters, ' ', '') + ';', rule, length - 1), declarations)
+						if (property > 0)
+							append(property > 32 ? declaration(characters + ';', rule, length - 1) : declaration(replace(characters, ' ', '') + ';', rule, length - 2), declarations)
 						break
 					// @ ;
 					case 59: characters += ';'
 					// { rule/at-rule
 					default:
-						append(reference = ruleset(characters, root, index, offset, rules, points, type, props = [], children = [], (pseudo = pseudo || inpseudo)), rulesets)
+						append(reference = ruleset(characters, root, index, offset, rules, points, type, props = [], children = [], length), rulesets)
 
 						if (character === 123)
 							if (offset === 0)
-								parse(characters, root, reference, props, rulesets, pseudo, points, children)
+								parse(characters, root, reference, props, rulesets, length, points, children)
 							else
 								switch (atrule) {
 									// d m s
 									case 100: case 109: case 115:
-										parse(value, reference, rule && append(ruleset(value, reference, 0, 0, rules, points, type, rules, props = [], pseudo), children), rules, children, pseudo, points, rule ? props : children)
+										parse(value, reference, rule && append(ruleset(value, reference, 0, 0, rules, points, type, rules, props = [], length), children), rules, children, length, points, rule ? props : children)
 										break
 									default:
-										parse(characters, reference, reference, [''], children, pseudo, points, children)
+										parse(characters, reference, reference, [''], children, length, points, children)
 								}
 				}
 
-				index = length = pseudo = offset = 0, variable = ampersand = 1, type = characters = ''
+				index = offset = property = 0, variable = ampersand = 1, type = characters = '', length = pseudo
 				break
 			// :
 			case 58:
-				length = strlen(characters), property = previous, pseudo = 1
+				length = 1 + strlen(characters), property = previous
 			default:
 				switch (characters += from(character), character * variable) {
 					// &

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -83,7 +83,7 @@ export function parse (value, root, rule, rules, rulesets, points, declarations)
 								switch (atrule) {
 									// d m s
 									case 100: case 109: case 115:
-										parse(value, reference, rule && append(ruleset(value, reference, 0, 0, rules, points, type, rules, props = []), children), rules, children, points, rule ? props : children, length)
+										parse(value, reference, rule && append(ruleset(value, reference, 0, 0, rules, points, type, rules, props = [], rule.length), children), rules, children, points, rule ? props : children, length)
 										break
 									default:
 										parse(characters, reference, reference, [''], children, points, children)

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -7,7 +7,7 @@ import {node, char, next, peek, caret, alloc, dealloc, delimit, whitespace, iden
  * @return {object[]}
  */
 export function compile (value) {
-	return dealloc(parse('', null, null, [''], value = alloc(value), [0], value))
+	return dealloc(parse('', null, null, [''], value = alloc(value), 0, [0], value))
 }
 
 /**
@@ -16,11 +16,12 @@ export function compile (value) {
  * @param {string[]} rule
  * @param {string[]} rules
  * @param {string[]} rulesets
+ * @param {number} pseudo
  * @param {number[]} points
  * @param {string[]} declarations
  * @return {object}
  */
-export function parse (value, root, rule, rules, rulesets, points, declarations) {
+export function parse (value, root, rule, rules, rulesets, pseudo, points, declarations) {
 	var index = 0
 	var offset = 0
 	var length = 0
@@ -74,19 +75,19 @@ export function parse (value, root, rule, rules, rulesets, points, declarations)
 					case 59: characters += ';'
 					// { rule/at-rule
 					default:
-						append(reference = ruleset(characters, root, index, offset, rules, points, type, props = [], children = [], length), rulesets)
+						append(reference = ruleset(characters, root, index, offset, rules, points, type, props = [], children = [], length || pseudo), rulesets)
 
 						if (character === 123)
 							if (offset === 0)
-								parse(characters, root, reference, props, rulesets, points, children)
+								parse(characters, root, reference, props, rulesets, length, points, children)
 							else
 								switch (atrule) {
 									// d m s
 									case 100: case 109: case 115:
-										parse(value, reference, rule && append(ruleset(value, reference, 0, 0, rules, points, type, rules, props = [], rule.length), children), rules, children, points, rule ? props : children, length)
+										parse(value, reference, rule && append(ruleset(value, reference, 0, 0, rules, points, type, rules, props = [], length || pseudo), children), rules, children, length, points, rule ? props : children)
 										break
 									default:
-										parse(characters, reference, reference, [''], children, points, children)
+										parse(characters, reference, reference, [''], children, length, points, children)
 								}
 				}
 

--- a/test/Middleware.js
+++ b/test/Middleware.js
@@ -47,5 +47,10 @@ describe('Middleware', () => {
     expect(serialize(compile(`a::placeholder{color:red;}`), middleware([prefixer, stringify]))).to.equal([
       `a::-webkit-input-placeholder{color:red;}`, `a::-moz-placeholder{color:red;}`, `a:-ms-input-placeholder{color:red;}`, `a::placeholder{color:red;}`
     ].join(''))
+
+    expect(serialize(compile(`textarea::placeholder{font-size:14px;@media{font-size:16px;}}`), middleware([prefixer, stringify]))).to.equal([
+      `textarea::-webkit-input-placeholder{font-size:14px;}textarea::-moz-placeholder{font-size:14px;}textarea:-ms-input-placeholder{font-size:14px;}textarea::placeholder{font-size:14px;}`,
+      `@media{textarea::-webkit-input-placeholder{font-size:16px;}textarea::-moz-placeholder{font-size:16px;}textarea:-ms-input-placeholder{font-size:16px;}textarea::placeholder{font-size:16px;}}`
+    ].join(''))
   })
 })

--- a/test/Middleware.js
+++ b/test/Middleware.js
@@ -59,5 +59,10 @@ describe('Middleware', () => {
       `div:-moz-read-write span{background-color:green;}`,
       `div:read-write span{background-color:green;}`
     ].join(''))
+
+    expect(serialize(compile(`div:read-write span{background-color:hotpink;}`), middleware([prefixer, stringify]))).to.equal([
+      `div:-moz-read-write span{background-color:hotpink;}`,
+      `div:read-write span{background-color:hotpink;}`
+    ].join(''))
   })
 })

--- a/test/Middleware.js
+++ b/test/Middleware.js
@@ -52,5 +52,12 @@ describe('Middleware', () => {
       `textarea::-webkit-input-placeholder{font-size:14px;}textarea::-moz-placeholder{font-size:14px;}textarea:-ms-input-placeholder{font-size:14px;}textarea::placeholder{font-size:14px;}`,
       `@media{textarea::-webkit-input-placeholder{font-size:16px;}textarea::-moz-placeholder{font-size:16px;}textarea:-ms-input-placeholder{font-size:16px;}textarea::placeholder{font-size:16px;}}`
     ].join(''))
+
+    expect(serialize(compile(`div:read-write{background-color:red;span{background-color:green;}}`), middleware([prefixer, stringify]))).to.equal([
+      `div:-moz-read-write{background-color:red;}`,
+      `div:read-write{background-color:red;}`,
+      `div:-moz-read-write span{background-color:green;}`,
+      `div:read-write span{background-color:green;}`
+    ].join(''))
   })
 })

--- a/test/Middleware.js
+++ b/test/Middleware.js
@@ -73,5 +73,10 @@ describe('Middleware', () => {
       `.placeholder:-ms-input-placeholder{background-color:hotpink;}`,
       `.read-write:read-write,.read-only:read-only,.placeholder::placeholder{background-color:hotpink;}`,
     ].join(''))
+
+    expect(serialize(compile(`:read-write{background-color:hotpink;}`), middleware([prefixer, stringify]))).to.equal([
+      `:-moz-read-write{background-color:hotpink;}`,
+      `:read-write{background-color:hotpink;}`
+    ].join(''))
   })
 })

--- a/test/Middleware.js
+++ b/test/Middleware.js
@@ -64,5 +64,14 @@ describe('Middleware', () => {
       `div:-moz-read-write span{background-color:hotpink;}`,
       `div:read-write span{background-color:hotpink;}`
     ].join(''))
+
+    expect(serialize(compile(`.read-write:read-write,.read-only:read-only,.placeholder::placeholder{background-color:hotpink;}`), middleware([prefixer, stringify]))).to.equal([
+      `.read-write:-moz-read-write{background-color:hotpink;}`,
+      `.read-only:-moz-read-only{background-color:hotpink;}`,
+      `.placeholder::-webkit-input-placeholder{background-color:hotpink;}`,
+      `.placeholder::-moz-placeholder{background-color:hotpink;}`,
+      `.placeholder:-ms-input-placeholder{background-color:hotpink;}`,
+      `.read-write:read-write,.read-only:read-only,.placeholder::placeholder{background-color:hotpink;}`,
+    ].join(''))
   })
 })


### PR DESCRIPTION
When working on `.parent` I've noticed that `ruleset` did not receive its final argument (`length`) in some cases which resulted in a "broken node" (`node.length === undefined`). After some digging into what `.length` actually does on rule nodes I was able to come up with a failing test for the code before the fix 