### PR TITLE
Remove unnecessary assignment

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -35,7 +35,7 @@ export function parse (value, root, rule, rules, rulesets, pseudo, points, decla
 	var type = ''
 	var props = rules
 	var children = rulesets
-	var reference = rule
+	var reference
 	var characters = type
 
 	while (scanning)


### PR DESCRIPTION
This value is only used inside this block:
https://github.com/thysultan/stylis.js/blob/24f984a77b2ccb41c5a2bf273b9af4be09c602c1/src/Parser.js#L78-L91
but it is actually reassigned at its very beginning, so the value with which it gets initialized is never used and the assignment can be removed