### PR TITLE
Add CJS export to conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
   "repository": "https://github.com/thysultan/stylis.js",
   "bugs": "https://github.com/thysultan/stylis.js/issues",
   "type": "module",
-  "main": "dist/stylis.umd.js",
+  "main": "dist/stylis.cjs",
   "module": "dist/stylis.esm.js",
-  "exports": "./index.js",
+  "exports": {
+    "import": "./index.js",
+    "require": "./dist/stylis.cjs"
+  },
   "files": [
     "index.js",
     "dist/",

--- a/script/build.js
+++ b/script/build.js
@@ -1,8 +1,8 @@
 import {join} from 'path'
-import {terser} from "rollup-plugin-terser"
+import {terser} from 'rollup-plugin-terser'
 import size from 'rollup-plugin-size'
 
-const options = {mangle: true, compress: false}
+const options = {mangle: true, compress: false, toplevel: true}
 const defaults = {
 	onwarn(warning, warn) {
 		switch (warning.code) {
@@ -18,6 +18,12 @@ const defaults = {
 
 export default ({configSrc = './', configInput = join(configSrc, 'index.js')}) => {
 	return [
+		{
+			...defaults,
+			input: configInput,
+			output: [{file: join(configSrc, 'dist', 'stylis.cjs'), format: 'cjs', name: 'stylis', freeze: false, sourcemap: true}],
+			plugins: [terser(options), size()]
+		},
 		{
 			...defaults,
 			input: configInput,


### PR DESCRIPTION
Without this, it wouldn't be possible to `require('stylis')` in nodes supporting conditional exports as `require` cannot load modules (in contrary to `import` which can load commonjs scripts)