### PR TITLE
chore: mark package free of side-effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Sultan Tarimo <sultantarimo@me.com>",
   "repository": "https://github.com/thysultan/stylis.js",
   "bugs": "https://github.com/thysultan/stylis.js/issues",
+  "sideEffects": false,
   "type": "module",
   "main": "dist/stylis.umd.js",
   "module": "dist/stylis.esm.js",


### PR DESCRIPTION
As previously [discussed on Twitter](https://twitter.com/kripod97/status/1254093637836836868), this should not cause any issues It would also allow displaying the sizes of individual exports [on Bundlephobia](https://bundlephobia.com/result?p=stylis).