### PR TITLE
Add carriage return to handled whitespace characters

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -45,8 +45,8 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
 			case 34: case 39: case 91: case 40:
 				characters += delimit(character)
 				break
-			// \t \n \s
-			case 9: case 10: case 32:
+			// \t \n \r \s
+			case 9: case 10: case 13: case 32:
 				characters += whitespace(previous)
 				break
 			// /

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -77,8 +77,8 @@ export function slice (begin, end) {
  */
 export function token (type) {
 	switch (type) {
-		// \0 \t \n \s whitespace token
-		case 0: case 9: case 10: case 32:
+		// \0 \t \n \r \s whitespace token
+		case 0: case 9: case 10: case 13: case 32:
 			return 5
 		// ! + , / > @ ~ isolate token
 		case 33: case 43: case 44: case 47: case 62: case 64: case 126:

--- a/test/Parser.js
+++ b/test/Parser.js
@@ -529,6 +529,8 @@ describe('Parser', () => {
   test('whitespace', () => {
     expect(
       stylis(`
+        @import\r\n "./a.css";
+
         div {
           ${'width:0;    '}
         }
@@ -537,6 +539,7 @@ describe('Parser', () => {
         }
       `)
     ).to.equal([
+      `@import "./a.css";`,
       `.user div{width:0;}`,
       `.user .foo{color:hotpink;}`
     ].join(''))


### PR DESCRIPTION
Given that `@import\n"./a.css";` works the same should work for `\r\n`