### PR TITLE
Fix an issue with double hyphen in an identifier switching to parsing css var declaration

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -117,7 +117,7 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
 						break
 					// -
 					case 45:
-						if (previous === 45)
+						if (previous === 45 && strlen(characters) == 2)
 							variable = 0
 				}
 		}

--- a/test/Parser.js
+++ b/test/Parser.js
@@ -699,6 +699,22 @@ describe('Parser', () => {
     ].join(''))
   })
 
+  test('`--` in an identifier (#220)', () => {
+    expect(
+      stylis(`
+        .block--modifier {
+          color: hotpink;
+        }
+        .card {
+          color: black;
+        }
+      `)
+    ).to.equal([
+      `.user .block--modifier{color:hotpink;}`,
+      `.user .card{color:black;}`
+    ].join(''))
+  })
+
   test('comments in rules not increasing depth of consecutive rules (#154)', () => {
     expect(
       stylis(`


### PR DESCRIPTION
fixes problem discovered when investigating https://github.com/thysultan/stylis.js/issues/220