### PR TITLE
Change package.json#main to `.cjs` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "pretest": "npm run lint && npm run build",
     "test": "nyc npm run spec",
     "spec": "mocha --harmony --require esm script/setup.js --recursive test",
+    "prebuild": "rimraf dist",
     "build": "rollup --config script/build.js --configSrc ./",
     "start": "rollup --config script/build.js --configSrc ./ --watch",
     "prepare": "npm run build",
@@ -34,15 +35,16 @@
     "release-patch": "npm version patch -m '%s'"
   },
   "devDependencies": {
-    "stylis": "./",
     "chai": "4.2.0",
     "eslint": "6.8.0",
     "esm": "3.2.25",
     "mocha": "7.0.0",
     "nyc": "15.0.0",
+    "rimraf": "^3.0.2",
     "rollup": "1.28.0",
+    "rollup-plugin-size": "0.2.1",
     "rollup-plugin-terser": "5.1.3",
-    "rollup-plugin-size": "0.2.1"
+    "stylis": "./"
   },
   "nyc": {
     "temp-dir": "./coverage/.nyc_output",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/thysultan/stylis.js/issues",
   "sideEffects": false,
   "type": "module",
-  "main": "dist/stylis.umd.js",
+  "main": "dist/stylis.cjs",
   "module": "dist/stylis.esm.js",
   "exports": {
     "import": "./index.js",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "spec": "mocha --harmony --require esm script/setup.js --recursive test",
     "prebuild": "rimraf dist",
     "build": "rollup --config script/build.js --configSrc ./",
-    "start": "rollup --config script/build.js --configSrc ./ --watch",
+    "start": "npm run build -- --watch",
     "prepare": "npm run build",
     "postversion": "git push --follow-tags && npm publish",
     "release-major": "npm version major -m '%s'",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "esm": "3.2.25",
     "mocha": "7.0.0",
     "nyc": "15.0.0",
-    "rimraf": "^3.0.2",
+    "rimraf": "3.0.2",
     "rollup": "1.28.0",
     "rollup-plugin-size": "0.2.1",
     "rollup-plugin-terser": "5.1.3",

--- a/script/build.js
+++ b/script/build.js
@@ -21,13 +21,7 @@ export default ({configSrc = './', configInput = join(configSrc, 'index.js')}) =
 		{
 			...defaults,
 			input: configInput,
-			output: [{file: join(configSrc, 'dist', 'stylis.cjs'), format: 'cjs', name: 'stylis', freeze: false, sourcemap: true}],
-			plugins: [terser(options), size()]
-		},
-		{
-			...defaults,
-			input: configInput,
-			output: [{file: join(configSrc, 'dist', 'stylis.umd.js'), format: 'umd', name: 'stylis', freeze: false, sourcemap: true}],
+			output: [{file: join(configSrc, 'dist', 'stylis.cjs'), format: 'umd', name: 'stylis', freeze: false, sourcemap: true}],
 			plugins: [terser(options), size()]
 		},
 		{


### PR DESCRIPTION
It seems that node@12.16.3 ships with unflagged module support BUT without support for conditional exports, so it just tries to use `"main"` but at the same type it sees `"type": "module"` and fails on `require`ing Stylis because it thinks it's going to load a module and it can't do that when using `require`.

This node version is used by Vercel and AWS, so it's pretty important for us to support them. The issue can be reproduced with this version of node using this repository: https://github.com/harrisrobin/vercel-deploy-issue