### PR TITLE
Better JSDoc types

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "lib": [
+            "esnext"
+        ],
+        "checkJs": true,
+        "noEmit": true,
+        "strict": true
+    },
+    "exclude": [
+        "**/node_modules/*"
+    ]
+}

--- a/src/Enum.js
+++ b/src/Enum.js
@@ -1,20 +1,74 @@
+/**
+ * @type {'-ms-'}
+ */
 export var MS = '-ms-'
+/**
+ * @type {'-moz-'}
+ */
 export var MOZ = '-moz-'
+/**
+ * @type {'-webkit-'}
+ */
 export var WEBKIT = '-webkit-'
 
+/**
+ * @type {'comm'}
+ */
 export var COMMENT = 'comm'
+/**
+ * @type {'rule'}
+ */
 export var RULESET = 'rule'
+/**
+ * @type {'decl'}
+ */
 export var DECLARATION = 'decl'
 
+/**
+ * @type {'@page'}
+ */
 export var PAGE = '@page'
+/**
+ * @type {'@media'}
+ */
 export var MEDIA = '@media'
+/**
+ * @type {'@import'}
+ */
 export var IMPORT = '@import'
+/**
+ * @type {'@charset'}
+ */
 export var CHARSET = '@charset'
+/**
+ * @type {'@viewport'}
+ */
 export var VIEWPORT = '@viewport'
+/**
+ * @type {'@supports'}
+ */
 export var SUPPORTS = '@supports'
+/**
+ * @type {'@document'}
+ */
 export var DOCUMENT = '@document'
+/**
+ * @type {'@namespace'}
+ */
 export var NAMESPACE = '@namespace'
+/**
+ * @type {'@keyframes'}
+ */
 export var KEYFRAMES = '@keyframes'
+/**
+ * @type {'@font-face'}
+ */
 export var FONT_FACE = '@font-face'
+/**
+ * @type {'@counter-style'}
+ */
 export var COUNTER_STYLE = '@counter-style'
+/**
+ * @type {'@font-feature-values'}
+ */
 export var FONT_FEATURE_VALUES = '@font-feature-values'

--- a/src/Middleware.js
+++ b/src/Middleware.js
@@ -5,31 +5,118 @@ import {serialize} from './Serializer.js'
 import {prefix} from './Prefixer.js'
 
 /**
- * @typedef {{
- * 	 parent?: Element,
- * 	 children?: Element[] | string,
- * 	 root: Element,
- * 	 type: string,
- * 	 props: string[] | string,
- * 	 value: string,
- * 	 length: number,
- * 	 return: string,
- * 	 line?: number,
- * 	 column?: number,
- * }} Element
+ * @typedef {Object} NodeBase
+ * @property {Node?} parent
+ * @property {Node?} root
+ * @property {string} value
+ * @property {number} length
+ * @property {string} return
+ * @property {number} line
+ * @property {number} column
+
+ * @typedef {NodeBase & {
+	type: 'comm'
+	props: string
+	children: string
+ }} CommentNode
+
+ * @typedef {NodeBase & {
+	type: 'decl'
+	props: string
+	children: string
+ }} DeclarationNode
+
+ * @typedef {NodeBase & {
+	type: 'rule'
+	props: string[]
+	children: Node[]
+ }} RulesetNode
+
+ * @typedef {NodeBase & {
+	type: '@keyframes'
+	props: string[]
+	children: Node[]
+ }} KeyframesNode
+
+* @typedef {NodeBase & {
+	type: '@media'
+	props: string[]
+	children: Node[]
+ }} MediaNode
+
+* @typedef {NodeBase & {
+	type: '@supports'
+	props: string[]
+	children: Node[]
+ }} SupportsNode
+
+ * @typedef {NodeBase & {
+	type: '@import'
+	props: []
+	children: []
+ }} ImportNode
+
+ * @typedef {NodeBase & {
+	type: '@charset'
+	props: []
+	children: []
+ }} CharsetNode
+
+* @typedef {NodeBase & {
+	type: '@counter-style'
+	props: string[]
+	children: DeclarationNode[]
+ }} CounterStyleNode
+
+ * @typedef {NodeBase & {
+	type: '@font-face'
+	props: []
+	children: DeclarationNode[]
+ }} FontFaceNode
+
+ * @typedef {NodeBase & {
+	type: '@page'
+	props: []
+	children: DeclarationNode[]
+ }} PageNode
+
+ * @typedef {NodeBase & {
+	type: '@document'
+	props: string[]
+	children: Node[]
+ }} DocumentNode
+
+ * @typedef {NodeBase & {
+	type: '@viewport'
+	props: []
+	children: DeclarationNode[]
+ }} ViewportNode
+
+ * @typedef {NodeBase & {
+	type: '@-webkit-keyframes'
+	props: string[]
+	children: Node[]
+ }} WebkitKeyframesNode
+
+ * @typedef {NodeBase & {
+	type: '@-moz-document'
+	props: string[]
+	children: Node[]
+ }} MozDocumentNode
+
+ * @typedef {NodeBase & {
+	type: '@-ms-viewport'
+	props: []
+	children: DeclarationNode[]
+ }} MsViewportNode
+
+ * @typedef {CommentNode | DeclarationNode | RulesetNode | KeyframesNode | MediaNode | SupportsNode | ImportNode | CharsetNode | CounterStyleNode | FontFaceNode | ViewportNode | PageNode | DocumentNode | WebkitKeyframesNode | MozDocumentNode | MsViewportNode} Node
 
  * @typedef {(
- * 	 value: string,
+ * 	 element: Node,
  * 	 index: number,
- * 	 array: string[],
- * 	) => string
- * } ArrayMapCallback
-
- * @typedef {(
- * 	 element: Element,
- * 	 index?: number,
- * 	 children?: (Element | string)[],
- * 	 callback?: Middleware,
+ * 	 children: Node[],
+ * 	 callback: Middleware,
  * 	) => string | void
  * } Middleware
  */
@@ -52,13 +139,15 @@ export function middleware (collection) {
 }
 
 /**
- * @param {(ret: string) => void} callback
+ * @param {(rule: string) => void} callback
  * @return {Middleware}
  */
 export function rulesheet (callback) {
 	return function (element) {
 		if (!element.root)
+			// @ts-ignore
 			if (element = element.return)
+				// @ts-ignore
 				callback(element)
 	}
 }
@@ -118,6 +207,7 @@ export function namespace (element) {
 							return index === 1 ? '' : value
 						default:
 							switch (index) {
+								// @ts-ignore
 								case 0: element = value
 									return sizeof(children) > 1 ? '' : value
 								case index = sizeof(children) - 1: case 2:

--- a/src/Middleware.js
+++ b/src/Middleware.js
@@ -5,8 +5,36 @@ import {serialize} from './Serializer.js'
 import {prefix} from './Prefixer.js'
 
 /**
- * @param {function[]} collection
- * @return {function}
+ * @typedef {{
+ * 	children?: Element[],
+ * 	length: number,
+ * 	props: string[],
+ * 	return: string,
+ * 	root: Element,
+ * 	parent?: Element,
+ * 	type: string,
+ * 	value: string,
+ * }} Element
+
+ * @typedef {(
+ *	 value: string,
+ *	 index: number,
+ *	 array: string[],
+ *	) => string
+ * } Callback
+
+ * @typedef {(
+ * 	 element: Element,
+ * 	 index?: number,
+ * 	 children?: Element[],
+ * 	 callback?: Middleware,
+ * 	) => string | void
+ * } Middleware
+ */
+
+/**
+ * @param {Middleware[]} collection
+ * @return {Middleware}
  */
 export function middleware (collection) {
 	var length = sizeof(collection)
@@ -22,22 +50,19 @@ export function middleware (collection) {
 }
 
 /**
- * @param {function} callback
- * @return {function}
+ * @param {(ret: string) => void} callback
+ * @return {Middleware}
  */
 export function rulesheet (callback) {
 	return function (element) {
 		if (!element.root)
 			if (element = element.return)
-				callback(element)
+				callback(/** @type {string} */ (element))
 	}
 }
 
 /**
- * @param {object} element
- * @param {number} index
- * @param {object[]} children
- * @param {function} callback
+ * @type {Middleware}
  */
 export function prefixer (element, index, children, callback) {
 	if (!element.return)
@@ -68,9 +93,7 @@ export function prefixer (element, index, children, callback) {
 }
 
 /**
- * @param {object} element
- * @param {number} index
- * @param {object[]} children
+ * @type {Middleware}
  */
 export function namespace (element) {
 	switch (element.type) {

--- a/src/Middleware.js
+++ b/src/Middleware.js
@@ -6,27 +6,29 @@ import {prefix} from './Prefixer.js'
 
 /**
  * @typedef {{
- * 	children?: Element[],
- * 	length: number,
- * 	props: string[],
- * 	return: string,
- * 	root: Element,
- * 	parent?: Element,
- * 	type: string,
- * 	value: string,
+ * 	 parent?: Element,
+ * 	 children?: Element[] | string,
+ * 	 root: Element,
+ * 	 type: string,
+ * 	 props: string[] | string,
+ * 	 value: string,
+ * 	 length: number,
+ * 	 return: string,
+ * 	 line?: number,
+ * 	 column?: number,
  * }} Element
 
  * @typedef {(
- *	 value: string,
- *	 index: number,
- *	 array: string[],
- *	) => string
- * } Callback
+ * 	 value: string,
+ * 	 index: number,
+ * 	 array: string[],
+ * 	) => string
+ * } ArrayMapCallback
 
  * @typedef {(
  * 	 element: Element,
  * 	 index?: number,
- * 	 children?: Element[],
+ * 	 children?: (Element | string)[],
  * 	 callback?: Middleware,
  * 	) => string | void
  * } Middleware

--- a/src/Middleware.js
+++ b/src/Middleware.js
@@ -57,7 +57,7 @@ export function rulesheet (callback) {
 	return function (element) {
 		if (!element.root)
 			if (element = element.return)
-				callback(/** @type {string} */ (element))
+				callback(element)
 	}
 }
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -2,27 +2,30 @@ import {COMMENT, RULESET, DECLARATION} from './Enum.js'
 import {abs, trim, from, sizeof, strlen, substr, append, replace} from './Utility.js'
 import {node, char, next, peek, caret, alloc, dealloc, delimit, whitespace, identifier, commenter} from './Tokenizer.js'
 
-/** @typedef {import('./Middleware.js').Element} Element */
+/** @typedef {import('./Middleware.js').Node} Node */
+/** @typedef {import('./Middleware.js').CommentNode} CommentNode */
+/** @typedef {import('./Middleware.js').DeclarationNode} DeclarationNode */
 
 /**
  * @param {string} value
- * @return {Element[]}
+ * @return {Node[]}
  */
 export function compile (value) {
+	// @ts-ignore
 	return dealloc(parse('', null, null, null, [''], value = alloc(value), 0, [0], value))
 }
 
 /**
  * @param {string} value
- * @param {Element} root
- * @param {Element?} parent
- * @param {Element[]} rule
+ * @param {Node?} root
+ * @param {Node?} parent
+ * @param {Node?} rule
  * @param {string[]} rules
- * @param {Element[]} rulesets
+ * @param {Node[]} rulesets
  * @param {number} pseudo
  * @param {number[]} points
- * @param {string[]} declarations
- * @return {Element[]}
+ * @param {Node[]} declarations
+ * @return {Node[]}
  */
 export function parse (value, root, parent, rule, rules, rulesets, pseudo, points, declarations) {
 	var index = 0
@@ -87,6 +90,7 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
 								switch (atrule) {
 									// d m s
 									case 100: case 109: case 115:
+										// @ts-ignore
 										parse(value, reference, reference, rule && append(ruleset(value, reference, reference, 0, 0, rules, points, type, rules, props = [], length), children), rules, children, length, points, rule ? props : children)
 										break
 									default:
@@ -129,17 +133,17 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
 
 /**
  * @param {string} value
- * @param {Element} root
- * @param {Element?} parent
+ * @param {Node?} root
+ * @param {Node?} parent
  * @param {number} index
  * @param {number} offset
  * @param {string[]} rules
  * @param {number[]} points
  * @param {string} type
  * @param {string[]} props
- * @param {Element[]} children
+ * @param {Node[]} children
  * @param {number} length
- * @return {Element}
+ * @return {Node}
  */
 export function ruleset (value, root, parent, index, offset, rules, points, type, props, children, length) {
 	var post = offset - 1
@@ -151,14 +155,15 @@ export function ruleset (value, root, parent, index, offset, rules, points, type
 			if (z = trim(j > 0 ? rule[x] + ' ' + y : replace(y, /&\f/g, rule[x])))
 				props[k++] = z
 
+	// @ts-ignore
 	return node(value, root, parent, offset === 0 ? RULESET : type, props, children, length)
 }
 
 /**
  * @param {string} value
- * @param {Element} root
- * @param {Element?} parent
- * @return {Element}
+ * @param {Node?} root
+ * @param {Node?} parent
+ * @return {CommentNode}
  */
 export function comment (value, root, parent) {
 	return node(value, root, parent, COMMENT, from(char()), substr(value, 2, -2), 0)
@@ -166,10 +171,10 @@ export function comment (value, root, parent) {
 
 /**
  * @param {string} value
- * @param {Element} root
- * @param {Element?} parent
+ * @param {Node?} root
+ * @param {Node?} parent
  * @param {number} length
- * @return {Element}
+ * @return {DeclarationNode}
  */
 export function declaration (value, root, parent, length) {
 	return node(value, root, parent, DECLARATION, substr(value, 0, length), substr(value, length + 1, -1), length)

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -2,9 +2,12 @@ import {COMMENT, RULESET, DECLARATION} from './Enum.js'
 import {abs, trim, from, sizeof, strlen, substr, append, replace} from './Utility.js'
 import {node, char, next, peek, caret, alloc, dealloc, delimit, whitespace, identifier, commenter} from './Tokenizer.js'
 
+/** @typedef {import('./Middleware.js').Element} Element */
+/** @typedef {string[]} Rulesets */
+
 /**
  * @param {string} value
- * @return {object[]}
+ * @return {Rulesets}
  */
 export function compile (value) {
 	return dealloc(parse('', null, null, null, [''], value = alloc(value), 0, [0], value))
@@ -12,15 +15,15 @@ export function compile (value) {
 
 /**
  * @param {string} value
- * @param {object} root
- * @param {object?} parent
- * @param {string[]} rule
+ * @param {Element} root
+ * @param {Element?} parent
+ * @param {Element | string[]} rule
  * @param {string[]} rules
- * @param {string[]} rulesets
- * @param {number[]} pseudo
+ * @param {Rulesets} rulesets
+ * @param {number} pseudo
  * @param {number[]} points
  * @param {string[]} declarations
- * @return {object}
+ * @return {Rulesets}
  */
 export function parse (value, root, parent, rule, rules, rulesets, pseudo, points, declarations) {
 	var index = 0
@@ -127,8 +130,8 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
 
 /**
  * @param {string} value
- * @param {object} root
- * @param {object?} parent
+ * @param {Element} root
+ * @param {Element?} parent
  * @param {number} index
  * @param {number} offset
  * @param {string[]} rules
@@ -137,7 +140,7 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
  * @param {string[]} props
  * @param {string[]} children
  * @param {number} length
- * @return {object}
+ * @return {Element}
  */
 export function ruleset (value, root, parent, index, offset, rules, points, type, props, children, length) {
 	var post = offset - 1
@@ -153,10 +156,10 @@ export function ruleset (value, root, parent, index, offset, rules, points, type
 }
 
 /**
- * @param {number} value
- * @param {object} root
- * @param {object?} parent
- * @return {object}
+ * @param {string} value
+ * @param {Element} root
+ * @param {Element?} parent
+ * @return {Element}
  */
 export function comment (value, root, parent) {
 	return node(value, root, parent, COMMENT, from(char()), substr(value, 2, -2), 0)
@@ -164,10 +167,10 @@ export function comment (value, root, parent) {
 
 /**
  * @param {string} value
- * @param {object} root
- * @param {object?} parent
+ * @param {Element} root
+ * @param {Element?} parent
  * @param {number} length
- * @return {object}
+ * @return {Element}
  */
 export function declaration (value, root, parent, length) {
 	return node(value, root, parent, DECLARATION, substr(value, 0, length), substr(value, length + 1, -1), length)

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -10,8 +10,7 @@ import {node, char, next, peek, caret, alloc, dealloc, delimit, whitespace, iden
  * @return {Rulesets}
  */
 export function compile (value) {
-	alloc(value)
-	return dealloc(parse('', null, null, null, [''], [], 0, [0], []))
+	return dealloc(parse('', null, null, null, [''], value = alloc(value), 0, [0], value))
 }
 
 /**

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -3,11 +3,10 @@ import {abs, trim, from, sizeof, strlen, substr, append, replace} from './Utilit
 import {node, char, next, peek, caret, alloc, dealloc, delimit, whitespace, identifier, commenter} from './Tokenizer.js'
 
 /** @typedef {import('./Middleware.js').Element} Element */
-/** @typedef {string} Ruleset */
 
 /**
  * @param {string} value
- * @return {Ruleset[]}
+ * @return {Element[]}
  */
 export function compile (value) {
 	return dealloc(parse('', null, null, null, [''], value = alloc(value), 0, [0], value))
@@ -17,13 +16,13 @@ export function compile (value) {
  * @param {string} value
  * @param {Element} root
  * @param {Element?} parent
- * @param {Element | string[]} rule
+ * @param {Element[]} rule
  * @param {string[]} rules
- * @param {Ruleset[]} rulesets
+ * @param {Element[]} rulesets
  * @param {number} pseudo
  * @param {number[]} points
  * @param {string[]} declarations
- * @return {Ruleset[]}
+ * @return {Element[]}
  */
 export function parse (value, root, parent, rule, rules, rulesets, pseudo, points, declarations) {
 	var index = 0

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -10,7 +10,8 @@ import {node, char, next, peek, caret, alloc, dealloc, delimit, whitespace, iden
  * @return {Rulesets}
  */
 export function compile (value) {
-	return dealloc(parse('', null, null, null, [''], value = alloc(value), 0, [0], value))
+	alloc(value)
+	return dealloc(parse('', null, null, null, [''], [], 0, [0], []))
 }
 
 /**
@@ -138,7 +139,7 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
  * @param {number[]} points
  * @param {string} type
  * @param {string[]} props
- * @param {string[]} children
+ * @param {Element[]} children
  * @param {number} length
  * @return {Element}
  */

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -3,11 +3,11 @@ import {abs, trim, from, sizeof, strlen, substr, append, replace} from './Utilit
 import {node, char, next, peek, caret, alloc, dealloc, delimit, whitespace, identifier, commenter} from './Tokenizer.js'
 
 /** @typedef {import('./Middleware.js').Element} Element */
-/** @typedef {string[]} Rulesets */
+/** @typedef {string} Ruleset */
 
 /**
  * @param {string} value
- * @return {Rulesets}
+ * @return {Ruleset[]}
  */
 export function compile (value) {
 	return dealloc(parse('', null, null, null, [''], value = alloc(value), 0, [0], value))
@@ -19,11 +19,11 @@ export function compile (value) {
  * @param {Element?} parent
  * @param {Element | string[]} rule
  * @param {string[]} rules
- * @param {Rulesets} rulesets
+ * @param {Ruleset[]} rulesets
  * @param {number} pseudo
  * @param {number[]} points
  * @param {string[]} declarations
- * @return {Rulesets}
+ * @return {Ruleset[]}
  */
 export function parse (value, root, parent, rule, rules, rulesets, pseudo, points, declarations) {
 	var index = 0

--- a/src/Serializer.js
+++ b/src/Serializer.js
@@ -1,11 +1,11 @@
 import {IMPORT, COMMENT, RULESET, DECLARATION} from './Enum.js'
 import {strlen, sizeof} from './Utility.js'
 
-/** @typedef {import('./Middleware.js').Element} Element */
+/** @typedef {import('./Middleware.js').Node} Node */
 /** @typedef {import('./Middleware.js').Middleware} Middleware */
 
 /**
- * @param {Element[]} children
+ * @param {Node[]} children
  * @param {Middleware} callback
  * @return {string}
  */
@@ -29,5 +29,6 @@ export function stringify (element, index, children, callback) {
 		case RULESET: element.value = element.props.join(',')
 	}
 
+	// @ts-ignore
 	return strlen(children = serialize(element.children, callback)) ? element.return = element.value + '{' + children + '}' : ''
 }

--- a/src/Serializer.js
+++ b/src/Serializer.js
@@ -1,9 +1,12 @@
 import {IMPORT, COMMENT, RULESET, DECLARATION} from './Enum.js'
 import {strlen, sizeof} from './Utility.js'
 
+/** @typedef {import('./Middleware.js').Element} Element */
+/** @typedef {import('./Middleware.js').Middleware} Middleware */
+
 /**
- * @param {object[]} children
- * @param {function} callback
+ * @param {Element[]} children
+ * @param {Middleware} callback
  * @return {string}
  */
 export function serialize (children, callback) {
@@ -17,11 +20,7 @@ export function serialize (children, callback) {
 }
 
 /**
- * @param {object} element
- * @param {number} index
- * @param {object[]} children
- * @param {function} callback
- * @return {string}
+ * @type {Middleware}
  */
 export function stringify (element, index, children, callback) {
 	switch (element.type) {

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -19,7 +19,7 @@ export var characters = ''
  * @param {number} length
  */
 export function node (value, root, parent, type, props, children, length) {
-	return {value, root, parent, type, props, children, line, column, length, return: ''}
+	return {value: value, root: root, parent: parent, type: type, props: props, children: children, line: line, column: column, length: length, return: ''}
 }
 
 /**

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -110,7 +110,7 @@ export function alloc (value) {
 }
 
 /**
- * @typedef {any} T
+ * @template T
  * @param {T} value
  * @return {T}
  */

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -103,7 +103,7 @@ export function token (type) {
 
 /**
  * @param {string} value
- * @return {[]}
+ * @return {unknown[]}
  */
 export function alloc (value) {
 	return line = column = 1, length = strlen(characters = value), position = 0, []
@@ -111,8 +111,8 @@ export function alloc (value) {
 
 /**
  * @template T
- * @param {T} value
- * @return {T}
+ * @param {T[]} value
+ * @return {T[]}
  */
 export function dealloc (value) {
 	return characters = '', value

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -7,22 +7,24 @@ export var position = 0
 export var character = 0
 export var characters = ''
 
+/** @typedef {import('./Middleware.js').Element} Element */
+
 /**
  * @param {string} value
- * @param {object} root
- * @param {object?} parent
+ * @param {Element} root
+ * @param {Element?} parent
  * @param {string} type
  * @param {string[]} props
- * @param {object[]} children
+ * @param {Element[]} children
  * @param {number} length
  */
 export function node (value, root, parent, type, props, children, length) {
-	return {value: value, root: root, parent: parent, type: type, props: props, children: children, line: line, column: column, length: length, return: ''}
+	return {value, root, parent, type, props, children, line, column, length, return: ''}
 }
 
 /**
  * @param {string} value
- * @param {object} root
+ * @param {Element} root
  * @param {string} type
  */
 export function copy (value, root, type) {
@@ -101,15 +103,16 @@ export function token (type) {
 
 /**
  * @param {string} value
- * @return {any[]}
+ * @return {[]}
  */
 export function alloc (value) {
 	return line = column = 1, length = strlen(characters = value), position = 0, []
 }
 
 /**
- * @param {any} value
- * @return {any}
+ * @typedef {any} T
+ * @param {T} value
+ * @return {T}
  */
 export function dealloc (value) {
 	return characters = '', value
@@ -192,7 +195,7 @@ export function delimiter (type) {
 /**
  * @param {number} type
  * @param {number} index
- * @return {number}
+ * @return {string}
  */
 export function commenter (type, index) {
 	while (next())

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -7,28 +7,33 @@ export var position = 0
 export var character = 0
 export var characters = ''
 
-/** @typedef {import('./Middleware.js').Element} Element */
+/** @typedef {import('./Middleware.js').Node} Node */
 
 /**
+ * @template {Node["type"]} T
  * @param {string} value
- * @param {Element} root
- * @param {Element?} parent
- * @param {string} type
- * @param {string[]} props
- * @param {Element[]} children
+ * @param {Node?} root
+ * @param {Node?} parent
+ * @param {T} type
+ * @param {Extract<Node, { type: T }>["props"]} props
+ * @param {Extract<Node, { type: T }>["children"]} children
  * @param {number} length
+ * @return {Extract<Node, { type: T }>}
  */
 export function node (value, root, parent, type, props, children, length) {
+	// @ts-ignore
 	return {value: value, root: root, parent: parent, type: type, props: props, children: children, line: line, column: column, length: length, return: ''}
 }
 
 /**
  * @param {string} value
- * @param {Element} root
+ * @param {Node} source
  * @param {string} type
+ * @return {Node}
  */
-export function copy (value, root, type) {
-	return node(value, root.root, root.parent, type, root.props, root.children, 0)
+export function copy (value, source, type) {
+	// @ts-ignore
+	return node(value, source.root, source.parent, type, source.props, source.children, 0)
 }
 
 /**
@@ -102,8 +107,9 @@ export function token (type) {
 }
 
 /**
+ * @template T
  * @param {string} value
- * @return {unknown[]}
+ * @return {T[]}
  */
 export function alloc (value) {
 	return line = column = 1, length = strlen(characters = value), position = 0, []

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -95,7 +95,7 @@ export function sizeof (value) {
 /**
  * @template T
  * @param {T} value
- * @param {any[]} array
+ * @param {T[]} array
  * @return {T}
  */
 export function append (value, array) {

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -93,7 +93,7 @@ export function sizeof (value) {
 }
 
 /**
- * @typedef {any} T
+ * @template T
  * @param {T} value
  * @param {any[]} array
  * @return {T}

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -32,11 +32,10 @@ export function trim (value) {
 /**
  * @param {string} value
  * @param {RegExp} pattern
- * @return {string}
+ * @return {string?}
  */
 export function match (value, pattern) {
-	var match = pattern.exec(value)
-	return match ? match[0] : value
+	return (value = pattern.exec(value)) ? value[0] : value
 }
 
 /**

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -1,3 +1,5 @@
+/** @typedef {import('./Middleware.js').Callback} Callback */
+
 /**
  * @param {number}
  * @return {number}
@@ -30,10 +32,11 @@ export function trim (value) {
 /**
  * @param {string} value
  * @param {RegExp} pattern
- * @return {string?}
+ * @return {string}
  */
 export function match (value, pattern) {
-	return (value = pattern.exec(value)) ? value[0] : value
+	var match = pattern.exec(value)
+	return match ? match[0] : value
 }
 
 /**
@@ -91,9 +94,10 @@ export function sizeof (value) {
 }
 
 /**
- * @param {any} value
+ * @typedef {any} T
+ * @param {T} value
  * @param {any[]} array
- * @return {any}
+ * @return {T}
  */
 export function append (value, array) {
 	return array.push(value), value
@@ -101,7 +105,7 @@ export function append (value, array) {
 
 /**
  * @param {string[]} array
- * @param {function} callback
+ * @param {Callback} callback
  * @return {string}
  */
 export function combine (array, callback) {

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -1,14 +1,10 @@
-/** @typedef {import('./Middleware.js').ArrayMapCallback} ArrayMapCallback */
-
 /**
- * @param {number}
- * @return {number}
+ * @type {(x: number) => number}
  */
 export var abs = Math.abs
 
 /**
- * @param {number}
- * @return {string}
+ * @type {(code: number) => string}
  */
 export var from = String.fromCharCode
 
@@ -35,6 +31,7 @@ export function trim (value) {
  * @return {string?}
  */
 export function match (value, pattern) {
+	// @ts-ignore
 	return (value = pattern.exec(value)) ? value[0] : value
 }
 
@@ -50,7 +47,7 @@ export function replace (value, pattern, replacement) {
 
 /**
  * @param {string} value
- * @param {string} value
+ * @param {string} search
  * @return {number}
  */
 export function indexof (value, search) {
@@ -104,7 +101,7 @@ export function append (value, array) {
 
 /**
  * @param {string[]} array
- * @param {ArrayMapCallback} callback
+ * @param {(value: string, index: number, array: string[]) => string} callback
  * @return {string}
  */
 export function combine (array, callback) {

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -1,4 +1,4 @@
-/** @typedef {import('./Middleware.js').Callback} Callback */
+/** @typedef {import('./Middleware.js').ArrayMapCallback} ArrayMapCallback */
 
 /**
  * @param {number}
@@ -104,7 +104,7 @@ export function append (value, array) {
 
 /**
  * @param {string[]} array
- * @param {Callback} callback
+ * @param {ArrayMapCallback} callback
  * @return {string}
  */
 export function combine (array, callback) {


### PR DESCRIPTION
I work almost exclusively in Typescript and not having type support is a show stopper for what is otherwise a lovely project. I looked at #208 and while I think it has good intentions the types are vague. That's not the PR author's fault - `tsc` just extracts the types from JSDoc. The JSDoc typings could be better.

I went through and _tried_ to fix it up. I removed all the instances of `object` and `function` with their real types. There are a few errors and maybe you can correct me on some assumptions I had to make about what is a possible data type but I think these are good types - specifically the use of `Middleware` as a type to explain that a function _is_ middleware (or returns middleware in the case of `rulesheet()`).

I arbitrarily picked Middleware.js to write the JSDoc `@typedef` but they could be anywhere - maybe index.js would be a better place?

I'll leave comments in the PR code to explain what I'm trying to do