### PR TITLE
Add react-native field to pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "type": "module",
   "main": "dist/stylis.cjs",
   "module": "dist/stylis.mjs",
+  "react-native": "./index.js",
   "exports": {
     "import": "./index.js",
     "require": "./dist/stylis.cjs"


### PR DESCRIPTION
fixes https://github.com/thysultan/stylis.js/issues/233

It seems that the Metro bundler used by React Native doesn't handle either `.mjs` nor `.cjs` - which is somewhat incorrect because files with unknown extensions have always just been loaded as `.js` in node. Some more info can be found in my comment [here](https://github.com/emotion-js/emotion/issues/1986#issuecomment-685133928) as well.

While technically it's not our issue and theirs - it's unknown when this will get fixed on their side and there are React Native consumers confused with this as stylis is not working for them out of the box. I believe that it's best to just fix this on our side for now.

This probably could have also been fixed by reverting this commit: https://github.com/thysultan/stylis.js/commit/180b9829101cf0132c5671a36b9e2daf0a5e28e7 . Pick your poison 😉 