### PR TITLE
Make pkg.json#main a .js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/thysultan/stylis.js/issues",
   "sideEffects": false,
   "type": "module",
-  "main": "dist/stylis.cjs",
+  "main": "dist/stylis.js",
   "module": "dist/stylis.mjs",
   "react-native": "./index.js",
   "exports": {

--- a/script/build.js
+++ b/script/build.js
@@ -21,6 +21,12 @@ export default ({configSrc = './', configInput = join(configSrc, 'index.js')}) =
 		{
 			...defaults,
 			input: configInput,
+			output: [{file: join(configSrc, 'dist', 'stylis.js'), format: 'umd', name: 'stylis', freeze: false, sourcemap: true}],
+			plugins: [terser(options), size()]
+		},
+		{
+			...defaults,
+			input: configInput,
 			output: [{file: join(configSrc, 'dist', 'stylis.cjs'), format: 'umd', name: 'stylis', freeze: false, sourcemap: true}],
 			plugins: [terser(options), size()]
 		},


### PR DESCRIPTION
JavaScript ecosystem strikes again 🤦 Explained here: https://github.com/emotion-js/emotion/issues/2103#issuecomment-727207340

I will understand if you don't want to merge this but it would make my life easier if this could be released as people wouldn't be hurt by the ecosystem tooling quirks and I wouldn't have to explain this 😢 