### PR TITLE
Fixed an issue with prefixer going into an infinite recursion

### DIFF
--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -67,16 +67,13 @@ export function prefix (value, length) {
 			if (strlen(value) - 1 - length > 6)
 				switch (charat(value, length + 1)) {
 					// (f)ill-available, (f)it-content
-					case 102:
-						if (charat(value, length + 3) === 108)
-							return replace(value, /(.+:)(.+)-([^]+)/, '$1' + WEBKIT + '$2-$3' + '$1' + MOZ + '$3') + value
+					case 102: length = charat(value, length + 3)
 					// (m)ax-content, (m)in-content
 					case 109:
-						return replace(value, /(.+:)(.+)-([^]+)/, '$1' + WEBKIT + '$2-$3' + '$1' + MOZ + '$2-$3') + value
-
+						return replace(value, /(.+:)(.+)-([^]+)/, '$1' + WEBKIT + '$2-$3' + '$1' + MOZ + (length == 108 ? '$3' : '$2-$3')) + value
 					// (s)tretch
 					case 115:
-						return prefix(replace(value, 'stretch', 'fill-available'), length) + value
+						return ~indexof(value, 'stretch') ? prefix(replace(value, 'stretch', 'fill-available'), length) + value : value
 				}
 			break
 		// position: sticky

--- a/test/Prefixer.js
+++ b/test/Prefixer.js
@@ -128,6 +128,7 @@ describe('Prefixer', () => {
 		expect(prefix(`width:var(--max-content);`, 5)).to.equal([`width:var(--max-content);`].join(''))
 		expect(prefix(`width:--max-content;`, 5)).to.equal([`width:--max-content;`].join(''))
 		expect(prefix(`width:fit-content;`, 5)).to.equal([`width:-webkit-fit-content;`, `width:-moz-fit-content;`, `width:fit-content;`].join(''))
+		expect(prefix(`width:stackWidth;`, 5)).to.equal([`width:stackWidth;`].join(''))
 		expect(prefix(`min-width:max-content;`, 9)).to.equal([`min-width:-webkit-max-content;`, `min-width:-moz-max-content;`, `min-width:max-content;`].join(''))
 		expect(prefix(`max-width:min-content;`, 9)).to.equal([`max-width:-webkit-min-content;`, `max-width:-moz-min-content;`, `max-width:min-content;`].join(''))
 		expect(prefix(`height:fill-available;`, 6)).to.equal([`height:-webkit-fill-available;`, `height:-moz-available;`, `height:fill-available;`].join(''))


### PR DESCRIPTION
It's something that has been reported here: https://github.com/emotion-js/emotion/issues/2117

Gonna think about a potential fix for this later.