### PR TITLE
Create commonjs package scope for the package.json#main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "bugs": "https://github.com/thysultan/stylis.js/issues",
   "sideEffects": false,
   "type": "module",
-  "main": "dist/stylis.js",
+  "main": "dist/umd/stylis.js",
   "module": "dist/stylis.mjs",
   "react-native": "./index.js",
   "exports": {
     "import": "./index.js",
-    "require": "./dist/stylis.cjs"
+    "require": "./dist/umd/stylis.js"
   },
   "files": [
     "index.js",

--- a/script/build.js
+++ b/script/build.js
@@ -2,6 +2,15 @@ import {join} from 'path'
 import {terser} from 'rollup-plugin-terser'
 import size from 'rollup-plugin-size'
 
+const emitPackageScopeFile = (type) => {
+	return {
+		name: 'emit-package-scope-file',
+		generateBundle() {
+			this.emitFile({ type: 'asset', fileName: 'package.json', source: `{ "type": "${type}" }\n` });
+		}
+	};
+}
+
 const options = {mangle: true, compress: false, toplevel: true}
 const defaults = {
 	onwarn(warning, warn) {
@@ -21,14 +30,8 @@ export default ({configSrc = './', configInput = join(configSrc, 'index.js')}) =
 		{
 			...defaults,
 			input: configInput,
-			output: [{file: join(configSrc, 'dist', 'stylis.js'), format: 'umd', name: 'stylis', freeze: false, sourcemap: true}],
-			plugins: [terser(options), size()]
-		},
-		{
-			...defaults,
-			input: configInput,
-			output: [{file: join(configSrc, 'dist', 'stylis.cjs'), format: 'umd', name: 'stylis', freeze: false, sourcemap: true}],
-			plugins: [terser(options), size()]
+			output: [{file: join(configSrc, 'dist', 'umd', 'stylis.js'), format: 'umd', name: 'stylis', freeze: false, sourcemap: true}],
+			plugins: [emitPackageScopeFile('commonjs'), terser(options), size()]
 		},
 		{
 			...defaults,


### PR DESCRIPTION
fixes https://github.com/thysultan/stylis.js/issues/247

I totally forgot that this thing was an issue - I have totally forgotten that there are versions of node that:
- have experimental (!) but unflagged (!) ESM support
- do not have support for conditional exports (at least not an unflagged one)

We already had this problem which got fixed here: https://github.com/thysultan/stylis.js/pull/228 🤦 

I've also attempted this exact thing before in https://github.com/thysultan/stylis.js/commit/eb58ad5549af328a361464f86864eb75a4c73a3b which was part of https://github.com/thysultan/stylis.js/pull/207 but we have settled on the alternative solution there so this hasn't ever been merged to the master branch.