### PR TITLE
Fix package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   "module": "dist/stylis.mjs",
   "react-native": "./index.js",
   "exports": {
-    "import": "./index.js",
-    "require": "./dist/umd/stylis.js",
+    "." : {
+      "import": "./index.js",
+      "require": "./dist/umd/stylis.js",
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "exports": {
     "." : {
       "import": "./index.js",
-      "require": "./dist/umd/stylis.js",
+      "require": "./dist/umd/stylis.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
@thysultan This patch is very important because right now stylis is not usable. Node 15 tells me `Invalid package config <my_project>\node_modules\stylis\package.json. "exports" cannot contain some keys starting with '.' and some not. The exports object must either be an object of package subpath keys or an object of main entry condition name keys only.` Sorry about this mistake I didn't about this. This should be fine after merging this.