### PR TITLE
Remove empty declarations

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -69,7 +69,7 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
 					case 0: case 125: scanning = 0
 					// ;
 					case 59 + offset:
-						if (property > 0)
+						if (property > 0 && (strlen(characters) - length))
 							append(property > 32 ? declaration(characters + ';', rule, parent, length - 1) : declaration(replace(characters, ' ', '') + ';', rule, parent, length - 2), declarations)
 						break
 					// @ ;

--- a/test/Parser.js
+++ b/test/Parser.js
@@ -430,6 +430,13 @@ describe('Parser', () => {
     ).to.equal(``)
   })
 
+  test('remove empty declarations', () => {
+    expect(stylis(`width:`)).to.equal(``)
+    expect(stylis(`height:;`)).to.equal(``)
+    expect(stylis(`max-width:     `)).to.equal(``)
+    expect(stylis(`max-height:     ;`)).to.equal(``)
+  })
+
   test('urls', () => {
     expect(
       stylis(`


### PR DESCRIPTION
Has been reported here: https://github.com/emotion-js/emotion/issues/2162

Apparently, it's a behavioral change from Stylis 3. I believe that it would be great to handle this case but it's up for discussion