### PR TITLE
Fix position:sticky; prefix for Safari browser

### DIFF
--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -86,7 +86,7 @@ export function prefix (value, length) {
 			switch (charat(value, strlen(value) - 3 - (~indexof(value, '!important') && 10))) {
 				// stic(k)y
 				case 107:
-					return replace(value, 'sticky', WEBKIT + 'sticky') + value
+					return replace(value, ':', ':' + WEBKIT) + value
 				// inline-b(o)x
 				case 111:
 					return replace(value, value, WEBKIT + value) + value

--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -84,8 +84,11 @@ export function prefix (value, length) {
 		// display: (flex|inline-flex|inline-box)
 		case 6444:
 			switch (charat(value, strlen(value) - 3 - (~indexof(value, '!important') && 10))) {
-				// stic(k)y, inline-b(o)x
-				case 107: case 111:
+				// stic(k)y
+				case 107:
+					return replace(value, 'sticky', WEBKIT + 'sticky') + value
+				// inline-b(o)x
+				case 111:
 					return replace(value, value, WEBKIT + value) + value
 				// (inline-)?fl(e)x
 				case 101:

--- a/test/Prefixer.js
+++ b/test/Prefixer.js
@@ -104,7 +104,7 @@ describe('Prefixer', () => {
 
 	test('position', () => {
 		expect(prefix(`position:relative;`, 8)).to.equal([`position:relative;`].join(''))
-		expect(prefix(`position:sticky;`, 8)).to.equal([`-webkit-position:sticky;`, `position:sticky;`].join(''))
+		expect(prefix(`position:sticky;`, 8)).to.equal([`position:-webkit-sticky;`, `position:sticky;`].join(''))
 	})
 
 	test('box', () => {


### PR DESCRIPTION
Fix #257

Source: https://www.w3schools.com/howto/howto_css_sticky_element.asp