### PR TITLE
Stop treating max() and min() CSS functions as prefixable max-content and min-content

### DIFF
--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -69,14 +69,14 @@ export function prefix (value, length) {
 			// stretch, max-content, min-content, fill-available
 			if (strlen(value) - 1 - length > 6)
 				switch (charat(value, length + 1)) {
-					// (f)ill-available, (f)it-content
-					case 102: length = charat(value, length + 3)
 					// (m)ax-content, (m)in-content
 					case 109:
 						// -
 						if (charat(value, length + 4) !== 45)
 							break
-						return replace(value, /(.+:)(.+)-([^]+)/, '$1' + WEBKIT + '$2-$3' + '$1' + MOZ + (length == 108 ? '$3' : '$2-$3')) + value
+					// (f)ill-available, (f)it-content
+					case 102:
+						return replace(value, /(.+:)(.+)-([^]+)/, '$1' + WEBKIT + '$2-$3' + '$1' + MOZ + (charat(value, length + 3) == 108 ? '$3' : '$2-$3')) + value
 					// (s)tretch
 					case 115:
 						return ~indexof(value, 'stretch') ? prefix(replace(value, 'stretch', 'fill-available'), length) + value : value

--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -73,6 +73,9 @@ export function prefix (value, length) {
 					case 102: length = charat(value, length + 3)
 					// (m)ax-content, (m)in-content
 					case 109:
+						// -
+						if (charat(value, length + 4) !== 45)
+							break
 						return replace(value, /(.+:)(.+)-([^]+)/, '$1' + WEBKIT + '$2-$3' + '$1' + MOZ + (length == 108 ? '$3' : '$2-$3')) + value
 					// (s)tretch
 					case 115:

--- a/test/Prefixer.js
+++ b/test/Prefixer.js
@@ -141,6 +141,12 @@ describe('Prefixer', () => {
 		expect(prefix(`width:stretch !important;`, 5)).to.equal([`width:-webkit-fill-available !important;`, `width:-moz-available !important;`, `width:fill-available !important;`, `width:stretch !important;`].join(''))
 		expect(prefix(`min-block-size:max-content;`, 14)).to.equal([`min-block-size:-webkit-max-content;`, `min-block-size:-moz-max-content;`, `min-block-size:max-content;`].join(''))
 		expect(prefix(`min-inline-size:max-content;`, 15)).to.equal([`min-inline-size:-webkit-max-content;`, `min-inline-size:-moz-max-content;`, `min-inline-size:max-content;`].join(''))
+		expect(prefix(`width:max(250px, 100px);`, 5)).to.equal([`width:max(250px, 100px);`].join(''))
+		expect(prefix(`height:min(150px, 200px);`, 6)).to.equal([`height:min(150px, 200px);`].join(''))
+		expect(prefix(`min-width:min(100px, 50px);`, 9)).to.equal([`min-width:min(100px, 50px);`].join(''))
+		expect(prefix(`max-width:max(150px, 200px);`, 9)).to.equal([`max-width:max(150px, 200px);`].join(''))
+		expect(prefix(`min-height:max(100px, 50px);`, 10)).to.equal([`min-height:max(100px, 50px);`].join(''))
+		expect(prefix(`max-height:min(150px, 200px);`, 10)).to.equal([`max-height:min(150px, 200px);`].join(''))
 	})
 
 	test('zoom', () => {


### PR DESCRIPTION
resolves https://github.com/emotion-js/emotion/issues/2306