### PR TITLE
fix / Escape chars in identifiers

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -99,6 +99,18 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
 				if (from(peek()).match(/[^a-f0-9]/i)) {
 					characters += '\\'
 					characters += from(next())
+				} else {
+					characters += '\\';
+					[1,2,3,4,5,6].some(() => {
+						if((from(peek()).match(/[a-f0-9]/i))) {
+							characters += from(next())
+							return false
+						}
+						return true
+					})
+					if((from(peek()).match(/\s/))) {
+						characters += from(next())
+					}
 				}
 				break
 			// :

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -94,6 +94,13 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
 
 				index = offset = property = 0, variable = ampersand = 1, type = characters = '', length = pseudo
 				break
+			// \
+			case 92:
+				if (from(peek()).match(/[^a-f0-9]/i)) {
+					characters += '\\'
+					characters += from(next())
+				}
+				break
 			// :
 			case 58:
 				length = 1 + strlen(characters), property = previous

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -1,6 +1,6 @@
 import {COMMENT, RULESET, DECLARATION} from './Enum.js'
 import {abs, trim, from, sizeof, strlen, substr, append, replace} from './Utility.js'
-import {node, char, prev, next, peek, caret, alloc, dealloc, delimit, whitespace, identifier, commenter} from './Tokenizer.js'
+import {node, char, prev, next, peek, caret, alloc, dealloc, delimit, whitespace, escaping, identifier, commenter} from './Tokenizer.js'
 
 /**
  * @param {string} value
@@ -49,6 +49,10 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
 			case 9: case 10: case 13: case 32:
 				characters += whitespace(previous)
 				break
+			// \
+			case 92:
+				characters += escaping(caret() - 1, 7)
+				continue
 			// /
 			case 47:
 				switch (peek()) {
@@ -94,36 +98,15 @@ export function parse (value, root, parent, rule, rules, rulesets, pseudo, point
 
 				index = offset = property = 0, variable = ampersand = 1, type = characters = '', length = pseudo
 				break
-			// \
-			case 92:
-				if (from(peek()).match(/[^a-f0-9]/i)) {
-					characters += '\\'
-					characters += from(next())
-				} else {
-					characters += '\\';
-					[1,2,3,4,5,6].some(() => {
-						if((from(peek()).match(/[a-f0-9]/i))) {
-							characters += from(next())
-							return false
-						}
-						return true
-					})
-					if((from(peek()).match(/\s/))) {
-						characters += from(next())
-					}
-				}
-				break
 			// :
 			case 58:
 				length = 1 + strlen(characters), property = previous
 			default:
-				if (variable < 1) {
-					if (character == 123) {
+				if (variable < 1)
+					if (character == 123)
 						--variable
-					} else if (character == 125 && variable++ == 0 && prev() == 125) {
+					else if (character == 125 && variable++ == 0 && prev() == 125)
 						continue
-					}
-				}
 
 				switch (characters += from(character), character * variable) {
 					// &

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -94,7 +94,7 @@ export function token (type) {
 			return 5
 		// ! + , / > @ ~ isolate token
 		case 33: case 43: case 44: case 47: case 62: case 64: case 126:
-		// ; { } / breakpoint token
+		// ; { } breakpoint token
 		case 59: case 123: case 125:
 			return 4
 		// : accompanied token
@@ -172,6 +172,20 @@ export function tokenizer (children) {
 		}
 
 	return children
+}
+
+/**
+ * @param {number} index
+ * @param {number} count
+ * @return {string}
+ */
+export function escaping (index, count) {
+	while (--count && next())
+		// not 0-9 A-F a-f
+		if (character < 48 || character > 102 || (character > 57 && character < 65) || (character > 70 && character < 97))
+			break
+
+	return slice(index, caret() + (count < 6 && peek() == 32 && next() == 32))
 }
 
 /**

--- a/test/Parser.js
+++ b/test/Parser.js
@@ -138,8 +138,16 @@ describe('Parser', () => {
         &.B\\&W{color:red;}
         &.\\@example\\.com{color:blue;}
         &.owner\\/founder{color:green;}
+        &.discount\\%  {color:purple;}
      `)
-    ).to.equal(`.user.B\\&W{color:red;}.user.\\@example\\.com{color:blue;}.user.owner\\/founder{color:green;}`)
+    ).to.equal([
+      '.user.B\\&W{color:red;}',
+      '.user.\\@example\\.com{color:blue;}',
+      '.user.owner\\/founder{color:green;}',
+      // while doubel spaces after escaped hex codes need to be preserved,
+      // after an escaped character / code point it need not be preserved 
+      '.user.discount\\%{color:purple;}'
+    ].join(''))
   });
 
   test('escaped hex codes in selector identifiers', () => {

--- a/test/Parser.js
+++ b/test/Parser.js
@@ -132,6 +132,16 @@ describe('Parser', () => {
     ).to.equal(`.user [href="https://css-tricks.com?a=1&b=2"]{color:red;}`)
   })
 
+  test('escape chars in selector identifiers', () => {
+    expect(
+      stylis(`
+        &.B\\&W{color:red;}
+        &.\\@example\\.com{color:blue;}
+        &.owner\\/founder{color:green;}
+     `)
+    ).to.equal(`.user.B\\&W{color:red;}.user.\\@example\\.com{color:blue;}.user.owner\\/founder{color:green;}`)
+  });
+
   test('comments', () => {
     expect(
       stylis(`

--- a/test/Parser.js
+++ b/test/Parser.js
@@ -144,7 +144,7 @@ describe('Parser', () => {
       '.user.B\\&W{color:red;}',
       '.user.\\@example\\.com{color:blue;}',
       '.user.owner\\/founder{color:green;}',
-      // while doubel spaces after escaped hex codes need to be preserved,
+      // while double spaces after escaped hex codes need to be preserved,
       // after an escaped character / code point it need not be preserved 
       '.user.discount\\%{color:purple;}'
     ].join(''))

--- a/test/Parser.js
+++ b/test/Parser.js
@@ -132,7 +132,7 @@ describe('Parser', () => {
     ).to.equal(`.user [href="https://css-tricks.com?a=1&b=2"]{color:red;}`)
   })
 
-  test('escape chars in selector identifiers', () => {
+  test('escaped chars in selector identifiers', () => {
     expect(
       stylis(`
         &.B\\&W{color:red;}
@@ -140,6 +140,26 @@ describe('Parser', () => {
         &.owner\\/founder{color:green;}
      `)
     ).to.equal(`.user.B\\&W{color:red;}.user.\\@example\\.com{color:blue;}.user.owner\\/founder{color:green;}`)
+  });
+
+  test('escaped hex digits in selector identifiers', () => {
+    expect(
+      stylis(`
+        &.B\\26W{color:red;}
+        &.B\\000026W{color:green;}
+        &.B\\26 W{color:blue;}
+        &.endsWith\\0000A9  a.childNode{color:green;}
+        &.endsWith\\AE  a.childNode{color:yellow;}
+     `)
+    ).to.equal([
+      '.user.B\\26W{color:red;}',
+      '.user.B\\000026W{color:green;}',
+      '.user.B\\26 W{color:blue;}',
+      // next rules are important because the hex digits terminating space
+      // is not the same as a combinator space
+      '.user.endsWith\\0000A9  a.childNode{color:green;}',
+      '.user.endsWith\\AE  a.childNode{color:yellow;}'
+    ].join(''))
   });
 
   test('comments', () => {

--- a/test/Parser.js
+++ b/test/Parser.js
@@ -142,24 +142,34 @@ describe('Parser', () => {
     ).to.equal(`.user.B\\&W{color:red;}.user.\\@example\\.com{color:blue;}.user.owner\\/founder{color:green;}`)
   });
 
-  test('escaped hex digits in selector identifiers', () => {
+  test('escaped hex codes in selector identifiers', () => {
     expect(
       stylis(`
         &.B\\26W{color:red;}
         &.B\\000026W{color:green;}
         &.B\\26 W{color:blue;}
-        &.endsWith\\0000A9  a.childNode{color:green;}
-        &.endsWith\\AE  a.childNode{color:yellow;}
-        &.Q\\000026A  a.childNode{color:purple;}
      `)
     ).to.equal([
       '.user.B\\26W{color:red;}',
       '.user.B\\000026W{color:green;}',
       '.user.B\\26 W{color:blue;}',
+    ].join(''))
+  });
+
+  test('double spaces after escaped hex codes in selector identifiers', () => {
+    expect(
+      stylis(`
+        &.endsWith\\0000A9  a.childNode{color:green;}
+        &.endsWith\\AE  a.childNode{color:yellow;}
+        &.Q\\000026A  a.childNode{color:purple;}
+     `)
+    ).to.equal([
       // next rules are important because the hex digits terminating space
       // is not the same as a combinator space
       '.user.endsWith\\0000A9  a.childNode{color:green;}',
       '.user.endsWith\\AE  a.childNode{color:yellow;}',
+      // max 6 hex chars in escape sequence - whitespace after 7th char
+      // is just normal whitespace and can be collapsed
       '.user.Q\\000026A a.childNode{color:purple;}',
     ].join(''))
   });

--- a/test/Parser.js
+++ b/test/Parser.js
@@ -150,6 +150,7 @@ describe('Parser', () => {
         &.B\\26 W{color:blue;}
         &.endsWith\\0000A9  a.childNode{color:green;}
         &.endsWith\\AE  a.childNode{color:yellow;}
+        &.Q\\000026A  a.childNode{color:purple;}
      `)
     ).to.equal([
       '.user.B\\26W{color:red;}',
@@ -158,7 +159,8 @@ describe('Parser', () => {
       // next rules are important because the hex digits terminating space
       // is not the same as a combinator space
       '.user.endsWith\\0000A9  a.childNode{color:green;}',
-      '.user.endsWith\\AE  a.childNode{color:yellow;}'
+      '.user.endsWith\\AE  a.childNode{color:yellow;}',
+      '.user.Q\\000026A a.childNode{color:purple;}',
     ].join(''))
   });
 


### PR DESCRIPTION
While working with emotion-js/styled, my team discovered that stylis is unable to parse CSS selectors which include escaped "special" characters. So a test like this:

```
  // add to test/Parser.js
  test.only('escaped chars in selector identifiers', () => {
    expect(
      stylis(`
        &.B\\&W{color:red;}
     `)
    ).to.equal(`.user.B\\&W{color:red;}`)
  });
```

Fails like this:

```
  1) Parser
       escaped chars in selector identifiers:

      AssertionError: expected '.user.B\\.userW{color:red;}' to equal '.user.B\\&W{color:red;}'
      + expected - actual

      -.user.B\.userW{color:red;}
      +.user.B\&W{color:red;}
      
      at Context.<anonymous> (test/Parser.js:140:10)
      at processImmediate (node:internal/timers:464:21)
```

Other special characters fail more spectacularly. Using `@` for example:

```
  test.only('escaped chars in selector identifiers', () => {
    expect(
      stylis(`
        &.B\\@W{color:red;}
     `)
    ).to.equal(`.user.B\\@W{color:red;}`)
  });
```

... yields the following result, with form feeds in the output:

```
1) Parser
       escaped chars in selector identifiers:

      AssertionError: expected '&\f.B\\@W{color:red;}' to equal '.user.B\\@W{color:red;}'
      + expected - actual

      -&
        .B\@W{color:red;}
      +.user.B\@W{color:red;}
      
      at Context.<anonymous> (test/Parser.js:140:10)
      at processImmediate (node:internal/timers:464:21)
```

-------

Various versions of the CSS recommendations mention that escape characters can be used.

From https://www.w3.org/TR/CSS2/syndata.html#characters
>  Identifiers can also contain escaped characters and any ISO 10646 character as a numeric code (see next item). For instance, the identifier "B&W?" may be written as "B\&W\?" or "B\26 W\3F".

From https://www.w3.org/TR/css-syntax-3/#escaping (non-normative)
> Any Unicode code point can be included in an identifier or quoted string by escaping it. CSS escape sequences start with a backslash (\), and continue with:
> * Any Unicode code point that is not a hex digits or a newline. The escape sequence is replaced by that code point.
> * Or one to six hex digits, followed by an optional whitespace. The escape sequence is replaced by the Unicode code point whose value is given by the hexadecimal digits. This optional whitespace allow hexadecimal escape sequences to be followed by "real" hex digits.

So in this PR I'm attempting to add some support for those behaviors to `stylis.js`